### PR TITLE
Xcode project: Set 'Skip install' flag on all targets

### DIFF
--- a/Build/Targets/universal-apple-macosx/Bento4.xcodeproj/project.pbxproj
+++ b/Build/Targets/universal-apple-macosx/Bento4.xcodeproj/project.pbxproj
@@ -3994,6 +3994,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = NO;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 10.5;
+				SKIP_INSTALL = YES;
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos macosx";
 				VALID_ARCHS = "i386 x86_64";
 				"VALID_ARCHS[sdk=iphoneos*]" = "armv6 armv7 armv7s arm64";
@@ -4014,6 +4015,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 10.5;
+				SKIP_INSTALL = YES;
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos macosx";
 				VALID_ARCHS = "i386 x86_64";
 				"VALID_ARCHS[sdk=iphoneos*]" = "armv6 armv7 armv7s arm64";


### PR DESCRIPTION
If you try to Build & Archive on a Mac or iOS project (which is how you
submit to the AppStores) with Bento4 as a subproject, Bento4 will get
entangled in that archive, making it un-submittable. Unless you
use the Build & Archive feature for Bento4, I suggest disabling archiving
for this library to ease integration into Mac and IOS projects.