### PR TITLE
iOS: Include x86_64 in VALID_ARCHS for simulator

### DIFF
--- a/Build/Targets/universal-apple-macosx/Bento4.xcodeproj/project.pbxproj
+++ b/Build/Targets/universal-apple-macosx/Bento4.xcodeproj/project.pbxproj
@@ -4062,7 +4062,7 @@
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos macosx";
 				VALID_ARCHS = "i386 x86_64";
 				"VALID_ARCHS[sdk=iphoneos*]" = "armv6 armv7 armv7s arm64";
-				"VALID_ARCHS[sdk=iphonesimulator*]" = i386;
+				"VALID_ARCHS[sdk=iphonesimulator*]" = "i386 x86_64";
 			};
 			name = Debug;
 		};
@@ -4083,7 +4083,7 @@
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos macosx";
 				VALID_ARCHS = "i386 x86_64";
 				"VALID_ARCHS[sdk=iphoneos*]" = "armv6 armv7 armv7s arm64";
-				"VALID_ARCHS[sdk=iphonesimulator*]" = i386;
+				"VALID_ARCHS[sdk=iphonesimulator*]" = "i386 x86_64";
 			};
 			name = Release;
 		};


### PR DESCRIPTION
‘cause the simulator is 64-bit now, and not including it causes linking errors (since the 64-bit simulator build of the app would be missing all Bento4 symbols)