### PR TITLE
improve CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,10 @@ set(SOURCE_SYSTEM ${SOURCE_ROOT}/System)
 # Compiler warning and optimization flags
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
 
+if (EMSCRIPTEN)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-warn-absolute-paths")
+endif()
+
 # AP4 Library
 file(GLOB AP4_SOURCES
   ${SOURCE_CODECS}/*.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,7 @@
+# cmake -DCMAKE_BUILD_TYPE=Debug ..
+# cmake -DCMAKE_BUILD_TYPE=Release ..
 cmake_minimum_required(VERSION 3.0)
+project(bento4)
 
 # Variables
 set(SOURCE_ROOT Source/C++)
@@ -7,6 +10,9 @@ set(SOURCE_CORE ${SOURCE_ROOT}/Core)
 set(SOURCE_CRYPTO ${SOURCE_ROOT}/Crypto)
 set(SOURCE_METADATA ${SOURCE_ROOT}/MetaData)
 set(SOURCE_SYSTEM ${SOURCE_ROOT}/System)
+
+# Compiler warning and optimization flags
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
 
 # AP4 Library
 file(GLOB AP4_SOURCES
@@ -32,12 +38,6 @@ include_directories(
   ${SOURCE_CRYPTO}
   ${SOURCE_METADATA}
 )
-
-# Compiler warning and optimization flags
-## cmake -DCMAKE_BUILD_TYPE=Debug ..
-set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wall -Wextra")
-## cmake -DCMAKE_BUILD_TYPE=Release ..
-set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -Wall -Wextra -O3")
 
 # Apps
 set(BENTO4_APPS "Aac2Mp4;Mp42Aac;Mp42Ts;Mp42Hls;Mp4Compact;Mp4DcfPackager;Mp4Decrypt;Mp4Dump;Mp4Edit;Mp4Encrypt;Mp4Extract;Mp4Fragment;Mp4Info;Mp4Mux;Mp4Split;Mp4Tag")


### PR DESCRIPTION
so now I've learned a little more about cmake.

A `project` name should be specified for VS.

The `-Wextra` option is an issue for VS.

The `-O3` flag is set by default for `-DCMAKE_BUILD_TYPE=Release` builds.