### PR TITLE
Fix uninitialized array.

### DIFF
--- a/Source/C++/Apps/Mp4Fragment/Mp4Fragment.cpp
+++ b/Source/C++/Apps/Mp4Fragment/Mp4Fragment.cpp
@@ -98,7 +98,7 @@ public:
         m_Track(track) {
         m_SampleCount = m_Track->GetSampleCount();
         if (m_SampleCount) {
-            m_ForcedSync = new bool[m_SampleCount];
+            m_ForcedSync = new bool[m_SampleCount]();
         } else {
             m_ForcedSync = NULL;
         }


### PR DESCRIPTION
The array of forced-sync samples (added for the --force-i-frame-sync option) is left uninitialized, which can cause inconsistencies in fragment locations, including fragmenting on non-keyframes.

I can reliably reproduce the issue using this test file: https://dl.dropboxusercontent.com/u/384584/bento4_fragment_test_sample.mp4

To reproduce:
```
$ mp4fragment --verbosity 2 --fragment-duration 2000 bento4_fragment_test_sample.mp4 output.m4f
```

Without the patch: 
```
fragment: track ID 1  59 samples
fragment: track ID 2  85 samples
fragment: track ID 1  60 samples <---- Wrong frame count; should be 59.
fragment: track ID 2  86 samples
fragment: track ID 1  60 samples <---- Wrong frame count; should be 59.
...
```

With the patch:
```
fragment: track ID 1  59 samples
fragment: track ID 2  85 samples
fragment: track ID 1  59 samples
fragment: track ID 2  85 samples
fragment: track ID 1  59 samples
...
```
