### PR TITLE
Don't try to match anchor track fragmenting after it is finished.

### DIFF
--- a/Source/C++/Apps/Mp4Fragment/Mp4Fragment.cpp
+++ b/Source/C++/Apps/Mp4Fragment/Mp4Fragment.cpp
@@ -444,7 +444,7 @@ Fragment(AP4_File&                input_file,
             target_dts = AP4_ConvertTime(anchor_cursor->m_Sample.GetDts(),
                                          anchor_cursor->m_Track->GetMediaTimeScale(),
                                          cursor->m_Track->GetMediaTimeScale());
-            if (target_dts <= cursor->m_Sample.GetDts()) {
+            if (anchor_cursor->m_Eos || target_dts <= cursor->m_Sample.GetDts()) {
                 // we must be at the end, past the last anchor sample, just use the target duration
                 target_dts = AP4_ConvertTime(fragment_duration*(cursor->m_FragmentIndex+1),
                                             1000,


### PR DESCRIPTION
When a secondary track (audio) is slightly longer than the anchor track (video), the mp4fragment tries to match the fragment durations, creating an unexpected short segment at the end, like so:

```
fragment: track ID 1  60 samples
fragment: track ID 2  86 samples
fragment: track ID 1  60 samples
fragment: track ID 2  86 samples
fragment: track ID 1  32 samples
fragment: track ID 2  46 samples
fragment: track ID 2   3 samples
```

So each fragment is approximately 2 seconds, except the final video fragment is about 1.07 seconds.  The audio is then fragmented into a 1.07 second fragment and a 0.035 second fragment, so that its durations match the video.

Instead, the final audio fragment should be allowed to be up to 2 seconds long, ensuring consistent fragmenting.  With this patch applied, the fragmenting looks like the following:

```
fragment: track ID 1  60 samples
fragment: track ID 2  86 samples
fragment: track ID 1  60 samples
fragment: track ID 2  86 samples
fragment: track ID 1  32 samples
fragment: track ID 2  49 samples
```
