### PR TITLE
Added the option --tfdt-offset=SEC to mp4fragment

### DIFF
--- a/Source/C++/Apps/Mp4Fragment/Mp4Fragment.cpp
+++ b/Source/C++/Apps/Mp4Fragment/Mp4Fragment.cpp
@@ -84,7 +84,7 @@ PrintUsageAndExit()
             "  --index (re)create the segment index\n"
             "  --trim trim excess media in longer tracks\n"
             "  --no-tfdt don't add 'tfdt' boxes in the fragments (may be needed for legacy Smooth Streaming clients)\n"
-            "  --tfdt-offset <sec> add a timeline offset to each 'tfdt' box in the fragment.\n"
+            "  --tfdt-offset <sec> add timeline offset to 'tfdt' boxes in the fragments.\n"
             "  --force-i-frame-sync <auto|all> treat all I-frames as sync samples (for open-gop sequences)\n"
             "    'auto' only forces the flag if an open-gop source is detected, 'all' forces the flag in all cases\n"
             );
@@ -276,7 +276,7 @@ Fragment(AP4_File&                input_file,
          AP4_UI32                 timescale,
          AP4_UI32                 track_id,
          bool                     create_segment_index,
-         unsigned int             tfdt_offset)
+         double                   tfdt_offset)
 {
     AP4_List<FragmentInfo> fragments;
     TrackCursor*           index_cursor = NULL;
@@ -588,7 +588,7 @@ Fragment(AP4_File&                input_file,
         
         traf->AddChild(tfhd);
         if (!Options.no_tfdt) {
-            AP4_TfdtAtom* tfdt = new AP4_TfdtAtom(1, cursor->m_Timestamp + tfdt_offset * cursor->m_Track->GetMediaTimeScale());
+            AP4_TfdtAtom* tfdt = new AP4_TfdtAtom(1, cursor->m_Timestamp + (unsigned int)(tfdt_offset * cursor->m_Track->GetMediaTimeScale()));
             traf->AddChild(tfdt);
         }
         AP4_UI32 trun_flags = AP4_TRUN_FLAG_DATA_OFFSET_PRESENT     |
@@ -1006,7 +1006,7 @@ main(int argc, char** argv)
     const char*  track_selector                = NULL;
     AP4_UI32     selected_track_id             = 0;
     unsigned int fragment_duration             = 0;
-    unsigned int tfdt_offset                   = 0;
+    double       tfdt_offset                   = 0.0;
     bool         auto_detect_fragment_duration = true;
     bool         create_segment_index          = false;
     bool         quiet                         = false;
@@ -1046,7 +1046,7 @@ main(int argc, char** argv)
                 fprintf(stderr, "ERROR: missing argument after --tfdt-offset option\n");
                 return 1;
             }
-            tfdt_offset = strtoul(arg, NULL, 10);
+            tfdt_offset = strtof(arg, NULL);
         } else if (!strcmp(arg, "--force-i-frame-sync")) {
             arg = *argv++;
             if (arg == NULL) {


### PR DESCRIPTION
The purpose with this option is to be able to add a timeline offset on each 'tfdt' box in the fragment. This makes it possible to reuse the timeline offset in an MPEG-TS segment when rewrapping on-the-fly to fragmented MP4. A use case for this is to be able to ingest HLS and on-the-fly rewrap to MPEG DASH using ffmpeg and Bento 4 applications.

## Example usage

```
   ffmpeg -i seg10.ts -bsf:a aac_adtstoasc -acodec copy -vn tmp_a.mp4
   ffmpeg -i seg10.ts -vcodec copy -an tmp_v.mp4
   mp4fragment --tfdt-offset <time from seg10.ts> tmp_a.mp4 audio-10.dash
   mp4fragment --tfdt-offset <time from seg10.ts> tmp_v.mp4 video-10.dash
```
