### PR TITLE
Support for roles in files containing multiple audio stream.

### DIFF
--- a/Source/Python/utils/mp4utils.py
+++ b/Source/Python/utils/mp4utils.py
@@ -360,6 +360,7 @@ class Mp4Track:
         self.max_segment_bitrate      = 0
         self.bandwidth                = 0
         self.language                 = ''
+        self.role                     = 'main'
         self.order_index              = 0
         self.id = info['id']
         if info['type'] == 'Audio':


### PR DESCRIPTION
Specify either via 

`--role-map 1:main,2:main,3:commentary,4:commentary`

or

 `--role-map-file roles.json`

with `roles.json` containing : 
```json
{"1":{"role":"main"}, "2":{"role":"main"}, "3":{"role":"commentary"}, "4":{"role":"commentary"}}
```

The output is compatible with DashJS player.