### PR TITLE
Fix the issue that duplicate AUDs are added and can't be played normally in MacOS.

### DIFF
--- a/Source/C++/Core/Ap4Mpeg2Ts.cpp
+++ b/Source/C++/Core/Ap4Mpeg2Ts.cpp
@@ -660,7 +660,7 @@ AP4_Mpeg2TsVideoSampleStream::WriteSample(AP4_Sample&            sample,
         
         // check if we need to add a delimiter before the NALU
         if (nalu_count == 0 && sample_description->GetType() == AP4_SampleDescription::TYPE_AVC) {
-            if (nalu_size != 2 || (data[0] & 0x1F) != AP4_AVC_NAL_UNIT_TYPE_ACCESS_UNIT_DELIMITER) {
+            if ((data[0] & 0x1F) != AP4_AVC_NAL_UNIT_TYPE_ACCESS_UNIT_DELIMITER) {
                 // the first NAL unit is not an Access Unit Delimiter, we need to add one
                 unsigned char delimiter[6];
                 delimiter[0] = 0;


### PR DESCRIPTION
[What] Fix the issue that duplicate AUDs are added when the input H.264 already has AUD. And the output HLS stream or the ts files can't be played normally in Safari/QuickTime player. (the frame display order becomes incorrect.)
[Why] The size of AUD in the sample are 3 and "nalu_size != 2" is always true, so AUDs are added.
[How] Remove the nalu_size checking and only check unit type.