### PR TITLE
Use sample description width/height for mp42hls --show-info

### DIFF
--- a/Source/C++/Apps/Mp42Hls/Mp42Hls.cpp
+++ b/Source/C++/Apps/Mp42Hls/Mp42Hls.cpp
@@ -2085,20 +2085,26 @@ main(int argc, char** argv)
         }
         if (video_track) {
             AP4_String codec;
+            AP4_UI16 width, height = 0;
             AP4_SampleDescription* sdesc = video_track->GetSampleDescription(0);
             if (sdesc) {
                 sdesc->GetCodecString(codec);
+                AP4_VideoSampleDescription* video_desc = AP4_DYNAMIC_CAST(AP4_VideoSampleDescription, sdesc);
+                if (video_desc) {
+                    width = video_desc->GetWidth();
+                    height = video_desc->GetHeight();
+                }
             }
             printf(
                 ",\n"
                 "  \"video\": {\n"
                 "    \"codec\": \"%s\",\n"
-                "    \"width\": %f,\n"
-                "    \"height\": %f\n"
+                "    \"width\": %d,\n"
+                "    \"height\": %d\n"
                 "  }",
                 codec.GetChars(),
-                (float)video_track->GetWidth()/65536.0,
-                (float)video_track->GetHeight()/65536.0
+                width,
+                height
             );
         }
         printf(

--- a/Source/C++/Apps/Mp42Hls/Mp42Hls.cpp
+++ b/Source/C++/Apps/Mp42Hls/Mp42Hls.cpp
@@ -2085,7 +2085,8 @@ main(int argc, char** argv)
         }
         if (video_track) {
             AP4_String codec;
-            AP4_UI16 width, height = 0;
+            AP4_UI16 width = (AP4_UI16)(video_track->GetWidth()/65536.0);
+            AP4_UI16 height = (AP4_UI16)(video_track->GetHeight()/65536.0);
             AP4_SampleDescription* sdesc = video_track->GetSampleDescription(0);
             if (sdesc) {
                 sdesc->GetCodecString(codec);


### PR DESCRIPTION
I was seeing oddness in my master playlists reporting the wrong resolution for some variants, and traced it down to the --show-info option for mp42hls utilizing the track's width/height, rather than the sample description's.  Seems that certain input files that had an pixel aspect ratio <> 1.0 would report odd resolutions (e.g., 853.333313x480.000000, which would round to 853x480 in the master playlist instead of the expected 854x480).

This pull request utilizes width and height from the track's sample description, if available.  Output is changed from a float to an integer, but mp4-hls.py seems to round the float to an integer anyway.