### PR TITLE
fix wrong path while splitting media files (audio)

### DIFF
--- a/Source/Python/utils/mp4-dash.py
+++ b/Source/Python/utils/mp4-dash.py
@@ -1565,16 +1565,16 @@ def main():
                     MakeNewDir(out_dir)
                 for audio_track in tracks:
                     if len(tracks) > 1:
-                        out_dir = path.join(out_dir, str(audio_track.order_index))
-                        MakeNewDir(out_dir)
+                        out_dir_tmp = path.join(out_dir, str(audio_track.order_index))
+                        MakeNewDir(out_dir_tmp )
                     print 'Splitting media file (audio)', GetMappedFileName(audio_track.parent.media_source.filename)
                     Mp4Split(options,
                              audio_track.parent.media_source.filename,
                              track_id               = str(audio_track.id),
                              pattern_parameters     = 'N',
                              start_number           = '1',
-                             init_segment           = path.join(out_dir, audio_track.init_segment_name),
-                             media_segment          = path.join(out_dir, SEGMENT_PATTERN))
+                             init_segment           = path.join(out_dir_tmp , audio_track.init_segment_name),
+                             media_segment          = path.join(out_dir_tmp , SEGMENT_PATTERN))
 
             if len(video_tracks):
                 MakeNewDir(path.join(options.output_dir, 'video'))


### PR DESCRIPTION
Splitted media files (audio) will be generated in directories like 'output\audio\und\mp4a\1' and 'output\audio\und\mp4a\1\2', which doesn't match the representation ids in mpd. We fix this problem in this patch, .