### PR TITLE
Add --query-string option to mp4-dash and mp4-hls.

### DIFF
--- a/Source/Python/utils/mp4-dash.py
+++ b/Source/Python/utils/mp4-dash.py
@@ -424,7 +424,7 @@ def OutputDash(options, set_attributes, audio_sets, video_sets, subtitles_sets, 
 
                 if options.on_demand:
                     base_url = xml.SubElement(representation, 'BaseURL')
-                    base_url.text = ONDEMAND_MEDIA_FILE_PATTERN % (options.media_prefix, video_track.representation_id)
+                    base_url.text = AppendQueryStringToFilename(options, ONDEMAND_MEDIA_FILE_PATTERN % (options.media_prefix, video_track.representation_id))
                     sidx_range = (video_track.sidx_atom.position, video_track.sidx_atom.position+video_track.sidx_atom.size-1)
                     init_range = (0, video_track.moov_atom.position+video_track.moov_atom.size-1)
                     segment_base = xml.SubElement(representation, 'SegmentBase', indexRange=str(sidx_range[0])+'-'+str(sidx_range[1]))
@@ -481,7 +481,7 @@ def OutputDash(options, set_attributes, audio_sets, video_sets, subtitles_sets, 
 
                 if options.on_demand:
                     base_url = xml.SubElement(representation, 'BaseURL')
-                    base_url.text = ONDEMAND_MEDIA_FILE_PATTERN % (options.media_prefix, audio_track.representation_id)
+                    base_url.text = AppendQueryStringToFilename(options, ONDEMAND_MEDIA_FILE_PATTERN % (options.media_prefix, audio_track.representation_id))
                     sidx_range = (audio_track.sidx_atom.position, audio_track.sidx_atom.position+audio_track.sidx_atom.size-1)
                     init_range = (0, audio_track.moov_atom.position+audio_track.moov_atom.size-1)
                     segment_base = xml.SubElement(representation, 'SegmentBase', indexRange=str(sidx_range[0])+'-'+str(sidx_range[1]))
@@ -514,7 +514,7 @@ def OutputDash(options, set_attributes, audio_sets, video_sets, subtitles_sets, 
 
                 if options.on_demand:
                     base_url = xml.SubElement(representation, 'BaseURL')
-                    base_url.text = ONDEMAND_MEDIA_FILE_PATTERN % (options.media_prefix, subtitles_track.representation_id)
+                    base_url.text = AppendQueryStringToFilename(options, ONDEMAND_MEDIA_FILE_PATTERN % (options.media_prefix, subtitles_track.representation_id))
                     sidx_range = (subtitles_track.sidx_atom.position, subtitles_track.sidx_atom.position+subtitles_track.sidx_atom.size-1)
                     init_range = (0, subtitles_track.moov_atom.position+subtitles_track.moov_atom.size-1)
                     segment_base = xml.SubElement(representation, 'SegmentBase', indexRange=str(sidx_range[0])+'-'+str(sidx_range[1]))
@@ -560,7 +560,7 @@ def OutputDash(options, set_attributes, audio_sets, video_sets, subtitles_sets, 
                                             id='subtitles/'+subtitles_file.language,
                                             bandwidth=str(bandwidth))
             base_url = xml.SubElement(representation, 'BaseURL')
-            base_url.text = 'subtitles/'+subtitles_file.language+'/'+subtitles_file.media_name
+            base_url.text = 'subtitles/' + subtitles_file.language + '/' + AppendQueryStringToFilename(options, subtitles_file.media_name)
 
     # save the MPD
     if options.mpd_filename:
@@ -1252,6 +1252,8 @@ def main():
                            "(2) the character '#' followed by the Primetime Metadata encoded in Base64")
     parser.add_option('', "--exec-dir", metavar="<exec_dir>", dest="exec_dir", default=default_exec_dir,
                       help="Directory where the Bento4 executables are located")
+    parser.add_option('', "--query-string", metavar="<query_string>", dest="query_string",
+                      help="Query string that is appended to resources in playlist files, useful when assets need to be requested with a version")
     (options, args) = parser.parse_args()
     if len(args) == 0:
         parser.print_help()

--- a/Source/Python/utils/mp4-hls.py
+++ b/Source/Python/utils/mp4-hls.py
@@ -185,7 +185,7 @@ def ProcessSource(options, media_info, out_dir):
     kwargs = {
         'index_filename':            path.join(out_dir, 'stream.m3u8'),
         'segment_filename_template': path.join(out_dir, 'segment-%d.'+file_extension),
-        'segment_url_template':      'segment-%d.'+file_extension,
+        'segment_url_template':      AppendQueryStringToFilename(options, 'segment-%d.'+file_extension),
         'show_info':                 True
     }
 
@@ -448,7 +448,7 @@ def OutputHls(options, media_sources):
                 ext_x_stream_inf += ',SUBTITLES="subtitles"'
 
             master_playlist.write(ext_x_stream_inf+'\r\n')
-            master_playlist.write(media['dir']+'/stream.m3u8\r\n')
+            master_playlist.write(media['dir'] + '/' + AppendQueryStringToFilename(options, 'stream.m3u8') + '\r\n')
 
     # write the I-FRAME playlist info
     if not audio_only and options.hls_version >= 4:
@@ -463,7 +463,7 @@ def OutputHls(options, media_sources):
                                         media_info['video']['codec'],
                                         int(media_info['video']['width']),
                                         int(media_info['video']['height']),
-                                        media['dir']+'/iframes.m3u8')
+                                        media['dir'] + '/' + AppendQueryStringToFilename(options, 'iframes.m3u8'))
             master_playlist.write(ext_x_i_frame_stream_inf+'\r\n')
 
 #############################################
@@ -525,6 +525,8 @@ def main():
                       help="Output the encryption key to a file (default: don't output the key). This option is only valid when the encryption key format is 'identity'")
     parser.add_option('', "--exec-dir", metavar="<exec_dir>", dest="exec_dir", default=default_exec_dir,
                       help="Directory where the Bento4 executables are located")
+    parser.add_option('', "--query-string", metavar="<query_string>", dest="query_string",
+                      help="Query string that is appended to resources in playlist files, useful when assets need to be requested with a version")
     (options, args) = parser.parse_args()
     if len(args) == 0:
         parser.print_help()

--- a/Source/Python/utils/mp4utils.py
+++ b/Source/Python/utils/mp4utils.py
@@ -726,6 +726,11 @@ def GetEncryptionKey(options, spec):
     else:
         raise Exception('Key Locator scheme not supported')
 
+def AppendQueryStringToFilename(options, filename):
+    if options.query_string:
+        filename += '?' + options.query_string
+    return filename
+
 # Compute the Dolby Digital AudioChannelConfiguration value
 #
 # (MSB = 0)


### PR DESCRIPTION
As we update pieces of video content and upload the resources to cloud storage, we bump up a version number that is associated with that piece of content. This is needed so that our CDN can load the new versions of the content when changes occur (thus bypassing the stale cached version that the CDN holds on to).