### PR TITLE
Unicode join in `mp4-dash.py`

### DIFF
--- a/Source/Python/utils/mp4-dash.py
+++ b/Source/Python/utils/mp4-dash.py
@@ -1684,7 +1684,7 @@ def main():
         else:
             for mp4_file in mp4_files.values():
                 print 'Processing and Copying media file', GetMappedFileName(mp4_file.media_source.filename)
-                media_filename = path.join(options.output_dir.decode('utf-8'), mp4_file.media_name)
+                media_filename = path.join(options.output_dir.decode('utf-8'), mp4_file.media_name).encode('utf8')
                 if not options.force_output and path.exists(media_filename):
                     PrintErrorAndExit('ERROR: file ' + media_filename + ' already exists')
 

--- a/Source/Python/utils/mp4-dash.py
+++ b/Source/Python/utils/mp4-dash.py
@@ -1684,7 +1684,7 @@ def main():
         else:
             for mp4_file in mp4_files.values():
                 print 'Processing and Copying media file', GetMappedFileName(mp4_file.media_source.filename)
-                media_filename = path.join(options.output_dir, mp4_file.media_name)
+                media_filename = path.join(options.output_dir.decode('utf-8'), mp4_file.media_name)
                 if not options.force_output and path.exists(media_filename):
                     PrintErrorAndExit('ERROR: file ' + media_filename + ' already exists')
 


### PR DESCRIPTION
in Python2.7 `path.join` is not able to join unicode strings.
Since `options.output_dir` is a user supplied argument it probably is a
unicode string now a days, so encode in properly.

This fixes the exception:

```
  File "/opt/sb4/stage/bin/mp4-dash.py", line 1336, in <module>
    main()
  File "/opt/sb4/stage/bin/mp4-dash.py", line 1308, in main
    shutil.copyfile(mp4_file.media_source.filename, media_filename)
  File "/opt/sb4/stage/lib/python2.7/shutil.py", line 68, in copyfile
    if _samefile(src, dst):
  File "/opt/sb4/stage/lib/python2.7/shutil.py", line 58, in _samefile
    return os.path.samefile(src, dst)
  File "/opt/sb4/stage/lib/python2.7/posixpath.py", line 156, in samefile
    s2 = os.stat(f2)
UnicodeEncodeError: 'ascii' codec can't encode character u'\xe4' in position 70: ordinal not in range(128)
```