### PR TITLE
Fix a bug: can not output encryption key

### DIFF
--- a/Source/Python/utils/mp4-hls.py
+++ b/Source/Python/utils/mp4-hls.py
@@ -551,7 +551,7 @@ def main():
 
     # check options
     if options.output_encryption_key:
-        if options.encryption_key_uri:
+        if options.encryption_key_uri != "key.bin":
             sys.stderr.write("WARNING: the encryption key will not be output because a non-default key URI was specified\n")
             options.output_encryption_key = False
         if not options.encryption_key:


### PR DESCRIPTION
Line 525: The command line option --encryption-key-uri has a default value: key.bin
Line 554: this if condition will always be True and block output_encryption_key option.