### PR TITLE
Fix memory leak (sidx atom).

### DIFF
--- a/Source/C++/Core/Ap4Processor.cpp
+++ b/Source/C++/Core/Ap4Processor.cpp
@@ -164,6 +164,7 @@ AP4_Processor::ProcessFragments(AP4_MoovAtom*              moov,
         // if this is not a moof atom, just write it back and continue
         if (atom->GetType() != AP4_ATOM_TYPE_MOOF) {
             result = atom->Write(output);
+            delete atom;
             if (AP4_FAILED(result)) return result;
             continue;
         }


### PR DESCRIPTION
Address Sanitizer report:

```
=================================================================
==23648==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 4752 byte(s) in 54 object(s) allocated from:
    #0 0x7f42d19d0060 in operator new(unsigned long) ../../../../gcc-7.3.0/libsanitizer/asan/asan_new_delete.cc:80
    #1 0x13ac856 in AP4_SidxAtom::Create(unsigned int, AP4_ByteStream&) Bento4-SRC-1-5-1-622/Source/C++/Core/Ap4SidxAtom.cpp:52
    #2 0x13dba9a in AP4_AtomFactory::CreateAtomFromStream(AP4_ByteStream&, unsigned int, unsigned int, unsigned long long, AP4_Atom*&) Bento4-SRC-1-5-1-622/Source/C++/Core/Ap4AtomFactory.cpp:692
    #3 0x13da15d in AP4_AtomFactory::CreateAtomFromStream(AP4_ByteStream&, unsigned long long&, AP4_Atom*&) Bento4-SRC-1-5-1-622/Source/C++/Core/Ap4AtomFactory.cpp:220
    #4 0x13d9f34 in AP4_AtomFactory::CreateAtomFromStream(AP4_ByteStream&, AP4_Atom*&) Bento4-SRC-1-5-1-622/Source/C++/Core/Ap4AtomFactory.cpp:150
    #5 0x13c7c05 in AP4_Processor::Process(AP4_ByteStream&, AP4_ByteStream&, AP4_ByteStream*, AP4_Processor::ProgressListener*, AP4_AtomFactory&) Bento4-SRC-1-5-1-622/Source/C++/Core/Ap4Processor.cpp:485
    #6 0x13c8fef in AP4_Processor::Process(AP4_ByteStream&, AP4_ByteStream&, AP4_ByteStream&, AP4_Processor::ProgressListener*, AP4_AtomFactory&) Bento4-SRC-1-5-1-622/Source/C++/Core/Ap4Processor.cpp:778

Indirect leak of 1080 byte(s) in 54 object(s) allocated from:
    #0 0x7f42d19d0060 in operator new(unsigned long) ../../../../gcc-7.3.0/libsanitizer/asan/asan_new_delete.cc:80
    #1 0x13ad47d in AP4_Array<AP4_SidxAtom::Reference>::EnsureCapacity(unsigned int) (/home/mlaurendeau/git/TitanLiveProcessUnit/bin/TitanLiveProcessUnit+0x13ad47d)
    #2 0x13ad382 in AP4_Array<AP4_SidxAtom::Reference>::SetItemCount(unsigned int) (/home/mlaurendeau/git/TitanLiveProcessUnit/bin/TitanLiveProcessUnit+0x13ad382)
    #3 0x13acace in AP4_SidxAtom::AP4_SidxAtom(unsigned int, unsigned char, unsigned int, AP4_ByteStream&) Bento4-SRC-1-5-1-622/Source/C++/Core/Ap4SidxAtom.cpp:104
    #4 0x13ac877 in AP4_SidxAtom::Create(unsigned int, AP4_ByteStream&) Bento4-SRC-1-5-1-622/Source/C++/Core/Ap4SidxAtom.cpp:52
    #5 0x13dba9a in AP4_AtomFactory::CreateAtomFromStream(AP4_ByteStream&, unsigned int, unsigned int, unsigned long long, AP4_Atom*&) Bento4-SRC-1-5-1-622/Source/C++/Core/Ap4AtomFactory.cpp:692
    #6 0x13da15d in AP4_AtomFactory::CreateAtomFromStream(AP4_ByteStream&, unsigned long long&, AP4_Atom*&) Bento4-SRC-1-5-1-622/Source/C++/Core/Ap4AtomFactory.cpp:220
    #7 0x13d9f34 in AP4_AtomFactory::CreateAtomFromStream(AP4_ByteStream&, AP4_Atom*&) Bento4-SRC-1-5-1-622/Source/C++/Core/Ap4AtomFactory.cpp:150
    #8 0x13c7c05 in AP4_Processor::Process(AP4_ByteStream&, AP4_ByteStream&, AP4_ByteStream*, AP4_Processor::ProgressListener*, AP4_AtomFactory&) Bento4-SRC-1-5-1-622/Source/C++/Core/Ap4Processor.cpp:485
    #9 0x13c8fef in AP4_Processor::Process(AP4_ByteStream&, AP4_ByteStream&, AP4_ByteStream&, AP4_Processor::ProgressListener*, AP4_AtomFactory&) Bento4-SRC-1-5-1-622/Source/C++/Core/Ap4Processor.cpp:778
```