### PR TITLE
Fix parsing of RPS NumDeltaPocs in SPS

### DIFF
--- a/Source/C++/Codecs/Ap4HevcParser.cpp
+++ b/Source/C++/Codecs/Ap4HevcParser.cpp
@@ -243,11 +243,15 @@ parse_st_ref_pic_set(AP4_HevcShortTermRefPicSet*         rps,
         /* abs_delta_rps_minus1 = */ ReadGolomb(bits);
         if (delta_idx_minus1+1 > stRpsIdx) return AP4_ERROR_INVALID_FORMAT; // should not happen
         unsigned int RefRpsIdx = stRpsIdx - (delta_idx_minus1 + 1);
-        unsigned int NumDeltaPocs = sps->short_term_ref_pic_sets[RefRpsIdx].num_negative_pics + sps->short_term_ref_pic_sets[RefRpsIdx].num_positive_pics;
+        unsigned int NumDeltaPocs = sps->short_term_ref_pic_sets[RefRpsIdx].num_delta_pocs;
         for (unsigned j=0; j<=NumDeltaPocs; j++) {
             unsigned int used_by_curr_pic_flag /*[j]*/ = bits.ReadBit();
+            unsigned int use_delta_flag /*[j]*/ = 1;
             if (!used_by_curr_pic_flag /*[j]*/) {
-                /* use_delta_flag[j] = */ bits.ReadBit();
+                use_delta_flag /*[j]*/ = bits.ReadBit();
+            }
+            if (used_by_curr_pic_flag /*[j]*/ || use_delta_flag /*[j]*/) {
+                rps->num_delta_pocs++;
             }
         }
     } else {
@@ -256,6 +260,7 @@ parse_st_ref_pic_set(AP4_HevcShortTermRefPicSet*         rps,
         if (rps->num_negative_pics > 16 || rps->num_positive_pics > 16) {
             return AP4_ERROR_INVALID_FORMAT;
         }
+        rps->num_delta_pocs = rps->num_negative_pics + rps->num_positive_pics;
         for (unsigned int i=0; i<rps->num_negative_pics; i++) {
             rps->delta_poc_s0_minus1[i] = ReadGolomb(bits);
             rps->used_by_curr_pic_s0_flag[i] = bits.ReadBit();

--- a/Source/C++/Codecs/Ap4HevcParser.h
+++ b/Source/C++/Codecs/Ap4HevcParser.h
@@ -161,6 +161,7 @@ typedef struct {
     unsigned int used_by_curr_pic_s1_flag[16];
     unsigned int num_negative_pics;
     unsigned int num_positive_pics;
+    unsigned int num_delta_pocs;
 } AP4_HevcShortTermRefPicSet;
 
 /*----------------------------------------------------------------------


### PR DESCRIPTION
`NumDeltaPocs` is not set correctly in case if `inter_ref_pic_set_prediction_flag` equals to 1.
See page 83 of Rec. ITU-T H.265.

Test case: [ducks.265.gz](https://github.com/axiomatic-systems/Bento4/files/2749670/ducks.265.gz)

```
$ ./Bento4-SDK-1-5-1-628.x86-microsoft-win32-vs2010/bin/mp4mux.exe --track ducks.265 ducks.mp4
ERROR: Feed() failed (-10)
ERROR: Feed() failed (-10)
ERROR: Feed() failed (-10)
ERROR: Feed() failed (-10)
ERROR: Feed() failed (-10)
ERROR: Feed() failed (-10)
ERROR: Feed() failed (-10)
```

After the fix, problem is gone. I also have private sample which causes segmentation fault of the `mp4mux` but can't share it with you unfortunately. It's also fixed by this PR.