### PR TITLE
Add copy udta support

### DIFF
--- a/Source/Python/utils/mp4-dash.py
+++ b/Source/Python/utils/mp4-dash.py
@@ -1535,6 +1535,7 @@ def main():
                         track_file.name,
                         track = str(track.id),
                         index = True,
+                        copy_udta = True,
                         quiet = True)
 
             media_source = MediaSource(track_file.name)


### PR DESCRIPTION
Dear authors:

To support pass of the udta for mp4 fragment under "on-demand" profiles, I think we need to add "copy_udta = True" option in mp4dash.py [1533    Mp4Fragment(...)].

Thanks.