### PR TITLE
Various MP4Decrypt fixes

### DIFF
--- a/Source/C++/Apps/Mp4Decrypt/Mp4Decrypt.cpp
+++ b/Source/C++/Apps/Mp4Decrypt/Mp4Decrypt.cpp
@@ -79,7 +79,8 @@ public:
 AP4_Result
 ProgressListener::OnProgress(unsigned int step, unsigned int total)
 {
-    printf("\r%d/%d", step, total);
+    fprintf(stdout, "\r%d/%d", step, total);
+    fflush(stdout);
     return AP4_SUCCESS;
 }
 

--- a/Source/C++/Core/Ap4CommonEncryption.cpp
+++ b/Source/C++/Core/Ap4CommonEncryption.cpp
@@ -2315,7 +2315,7 @@ AP4_CencFragmentDecrypter::ProcessSample(AP4_DataBuffer& data_in,
 /*----------------------------------------------------------------------
 |   AP4_CencDecryptingProcessor::AP4_CencDecryptingProcessor
 +---------------------------------------------------------------------*/
-AP4_CencDecryptingProcessor::AP4_CencDecryptingProcessor(const AP4_ProtectionKeyMap* key_map, 
+AP4_CencDecryptingProcessor::AP4_CencDecryptingProcessor(AP4_ProtectionKeyMap* key_map,
                                                          AP4_BlockCipherFactory*     block_cipher_factory) :
     m_KeyMap(key_map)
 {
@@ -2358,6 +2358,20 @@ AP4_CencDecryptingProcessor::CreateTrackHandler(AP4_TrakAtom* trak)
                 protected_desc->GetSchemeType() == AP4_PROTECTION_SCHEME_TYPE_CBCS) {
                 sample_descs.Append(protected_desc);
                 sample_entries.Append(sample_entry);
+            }
+
+            AP4_ContainerAtom* schi = protected_desc->GetSchemeInfo()->GetSchiAtom();
+            if (schi != NULL) {
+                AP4_CencTrackEncryption* tenc;
+                if (protected_desc->GetSchemeType() == AP4_PROTECTION_SCHEME_TYPE_PIFF) {
+                    tenc = AP4_DYNAMIC_CAST(AP4_CencTrackEncryption, schi->GetChild(AP4_ATOM_TYPE_UUID));
+                } else {
+                    tenc = AP4_DYNAMIC_CAST(AP4_CencTrackEncryption, schi->GetChild(AP4_ATOM_TYPE_TENC));
+                }
+                if (tenc != NULL) {
+                    const AP4_DataBuffer* key = m_KeyMap->GetKeyByKid(tenc->GetDefaultKid());
+                    if (key != NULL) m_KeyMap->SetKey(trak->GetId(), key->GetData(), 16);
+                }
             }
         }
     }

--- a/Source/C++/Core/Ap4CommonEncryption.h
+++ b/Source/C++/Core/Ap4CommonEncryption.h
@@ -653,7 +653,7 @@ class AP4_CencDecryptingProcessor : public AP4_Processor
 {
 public:
     // constructor
-    AP4_CencDecryptingProcessor(const AP4_ProtectionKeyMap* key_map, 
+    AP4_CencDecryptingProcessor(AP4_ProtectionKeyMap* key_map,
                                 AP4_BlockCipherFactory*     block_cipher_factory = NULL);
 
     // AP4_Processor methods
@@ -667,7 +667,7 @@ public:
 protected:    
     // members
     AP4_BlockCipherFactory*     m_BlockCipherFactory;
-    const AP4_ProtectionKeyMap* m_KeyMap;
+    AP4_ProtectionKeyMap* m_KeyMap;
 };
 
 /*----------------------------------------------------------------------

--- a/Source/C++/Core/Ap4Processor.cpp
+++ b/Source/C++/Core/Ap4Processor.cpp
@@ -143,6 +143,7 @@ AP4_Processor::ProcessFragments(AP4_MoovAtom*              moov,
                                 AP4_ContainerAtom*         mfra,
                                 AP4_SidxAtom*              sidx,
                                 AP4_Position               sidx_position,
+                                ProgressListener*          listener,
                                 AP4_ByteStream&            input, 
                                 AP4_ByteStream&            output)
 {
@@ -369,6 +370,11 @@ AP4_Processor::ProcessFragments(AP4_MoovAtom*              moov,
         }
         for (unsigned int i=0; i<sample_tables.ItemCount(); i++) {
             delete sample_tables[i];
+        }
+
+        // notify the progress listener
+        if (listener) {
+            listener->OnProgress(fragment_index+1, atoms.ItemCount());
         }
     }
     
@@ -692,7 +698,7 @@ AP4_Processor::Process(AP4_ByteStream&   input,
             AP4_ASSERT(after-before == mdat_payload_size);
 #endif
         }
-        
+
         // find the position of the sidx atom
         AP4_Position sidx_position = 0;
         if (sidx) {
@@ -708,7 +714,7 @@ AP4_Processor::Process(AP4_ByteStream&   input,
         }
         
         // process the fragments, if any
-        result = ProcessFragments(moov, frags, mfra, sidx, sidx_position, fragments?*fragments:input, output);
+        result = ProcessFragments(moov, frags, mfra, sidx, sidx_position, listener, fragments?*fragments:input, output);
         if (AP4_FAILED(result)) return result;
         
         // update and re-write the sidx if we have one
@@ -745,7 +751,7 @@ AP4_Processor::Process(AP4_ByteStream&   input,
         // so we need to delete it here
         delete moov;
     }
-    
+
     return AP4_SUCCESS;
 }
 

--- a/Source/C++/Core/Ap4Processor.h
+++ b/Source/C++/Core/Ap4Processor.h
@@ -263,6 +263,7 @@ protected:
                                 AP4_ContainerAtom*         mfra,
                                 AP4_SidxAtom*              sidx,
                                 AP4_Position               sidx_position,
+                                ProgressListener*          listener,
                                 AP4_ByteStream&            input, 
                                 AP4_ByteStream&            output);
     


### PR DESCRIPTION
Fixed MP4Decrypt so it can:
- Decrypt PIFF media
- Select track by KID instead of track ID
- Show progress