### PR TITLE
Fix for #133 : Remove AP4_LINEAR_READER_DEFAULT_BUFFER_SIZE limitation

### DIFF
--- a/Source/C++/Core/Ap4LinearReader.cpp
+++ b/Source/C++/Core/Ap4LinearReader.cpp
@@ -41,8 +41,7 @@
 |   AP4_LinearReader::AP4_LinearReader
 +---------------------------------------------------------------------*/
 AP4_LinearReader::AP4_LinearReader(AP4_Movie&      movie, 
-                                   AP4_ByteStream* fragment_stream,
-                                   AP4_Size        max_buffer) :
+                                   AP4_ByteStream* fragment_stream) :
     m_Movie(movie),
     m_Fragment(NULL),
     m_FragmentStream(fragment_stream),
@@ -50,7 +49,6 @@ AP4_LinearReader::AP4_LinearReader(AP4_Movie&      movie,
     m_NextFragmentPosition(0),
     m_BufferFullness(0),
     m_BufferFullnessPeak(0),
-    m_MaxBufferFullness(max_buffer),
     m_Mfra(NULL)
 {
     m_HasFragments = movie.HasFragments();
@@ -404,11 +402,7 @@ AP4_LinearReader::AdvanceFragment()
 AP4_Result
 AP4_LinearReader::Advance(bool read_data)
 {
-    // first, check if we have space to advance
-    if (m_BufferFullness >= m_MaxBufferFullness) {
-        return AP4_ERROR_NOT_ENOUGH_SPACE;
-    }
-    
+
     AP4_UI64 min_offset = (AP4_UI64)(-1);
     Tracker* next_tracker = NULL;
     for (;;) {

--- a/Source/C++/Core/Ap4LinearReader.h
+++ b/Source/C++/Core/Ap4LinearReader.h
@@ -50,14 +50,12 @@ class AP4_MovieFragment;
 const unsigned int AP4_LINEAR_READER_INITIALIZED = 1;
 const unsigned int AP4_LINEAR_READER_FLAG_EOS    = 2;
 
-const unsigned int AP4_LINEAR_READER_DEFAULT_BUFFER_SIZE = 16*1024*1024;
-
 /*----------------------------------------------------------------------
 |   AP4_LinearReader
 +---------------------------------------------------------------------*/
 class AP4_LinearReader {
 public:
-    AP4_LinearReader(AP4_Movie& movie, AP4_ByteStream* fragment_stream = NULL, AP4_Size max_buffer=AP4_LINEAR_READER_DEFAULT_BUFFER_SIZE);
+    AP4_LinearReader(AP4_Movie& movie, AP4_ByteStream* fragment_stream = NULL);
     virtual ~AP4_LinearReader();
     
     AP4_Result EnableTrack(AP4_UI32 track_id);
@@ -184,7 +182,6 @@ protected:
     AP4_Array<Tracker*> m_Trackers;
     AP4_Size            m_BufferFullness;
     AP4_Size            m_BufferFullnessPeak;
-    AP4_Size            m_MaxBufferFullness;
     AP4_ContainerAtom*  m_Mfra;
 };
 

--- a/Source/C++/Core/Ap4Results.h
+++ b/Source/C++/Core/Ap4Results.h
@@ -55,7 +55,6 @@ const int AP4_ERROR_INVALID_TRACK_TYPE              = -19;
 const int AP4_ERROR_INVALID_RTP_PACKET_EXTRA_DATA   = -20;
 const int AP4_ERROR_BUFFER_TOO_SMALL                = -21;
 const int AP4_ERROR_NOT_ENOUGH_DATA                 = -22;
-const int AP4_ERROR_NOT_ENOUGH_SPACE                = -23;
 
 /*----------------------------------------------------------------------
 |   utility functions


### PR DESCRIPTION
Fixes #133 which is triggered by High bit rate files with large GOP size (AP4_ERROR_NOT_ENOUGH_SPACE -23;)

Following logic of https://github.com/axiomatic-systems/Bento4/commit/61b201265e6f6d14fe3e85d87de66c45f7a2840b I removed the AP4_ERROR_NOT_ENOUGH_SPACE check.
