### PR TITLE
Fix --segment-filename-template applied to segment files, not m3u8 files

### DIFF
--- a/Source/C++/Apps/Mp42Hls/Mp42Hls.cpp
+++ b/Source/C++/Apps/Mp42Hls/Mp42Hls.cpp
@@ -1808,11 +1808,7 @@ main(int argc, char** argv)
             }
         }
         if (Options.segment_url_template == NULL) {
-            if (Options.output_single_file) {
-                Options.segment_url_template = "stream.ts";
-            } else {
-                Options.segment_url_template = "segment-%d.ts";
-            }
+            Options.segment_url_template = Options.segment_filename_template;
         }
     }
     


### PR DESCRIPTION
Reproduct:
$ mp42hls --segment-filename-template 'seg-%03d.ts' --hls-version 4 fragmented.mp4

$ ls -1 *.m3u8 *.ts
iframes.m3u8
seg-000.ts
seg-001.ts
stream.m3u8

$ cat *.m3u8
    #EXTM3U
    #EXT-X-VERSION:4
    #EXT-X-PLAYLIST-TYPE:VOD
    #EXT-X-I-FRAMES-ONLY
    #EXT-X-INDEPENDENT-SEGMENTS
    #EXT-X-TARGETDURATION:33
    #EXT-X-MEDIA-SEQUENCE:0
    #EXTINF:33.433400,
    #EXT-X-BYTERANGE:131036@376
    segment-0.ts
    #EXTINF:30.630600,
    #EXT-X-BYTERANGE:233872@376
    segment-1.ts
    #EXT-X-ENDLIST
    #EXTM3U
    #EXT-X-VERSION:4
    #EXT-X-PLAYLIST-TYPE:VOD
    #EXT-X-INDEPENDENT-SEGMENTS
    #EXT-X-TARGETDURATION:33
    #EXT-X-MEDIA-SEQUENCE:0
    #EXTINF:33.433400,
    segment-0.ts
    #EXTINF:30.630600,
    segment-1.ts
    #EXT-X-ENDLIST