### PR TITLE
Ap4StreamCipher: fix skip bytes calculation.

### DIFF
--- a/Source/C++/Crypto/Ap4StreamCipher.cpp
+++ b/Source/C++/Crypto/Ap4StreamCipher.cpp
@@ -581,7 +581,7 @@ AP4_PatternStreamCipher::ProcessBuffer(const AP4_UI08* in,
             crypt_size = (m_CryptByteBlock-pattern_position)*16;
         } else {
             // in the skipped part
-            skip_size = pattern_span-pattern_position;
+            skip_size = (pattern_span-pattern_position)*16;
         }
         
         // clip


### PR DESCRIPTION
As far as I can see, `skip_size` should be in bytes.
However, in this line, it is set in blocks.
This results in incorrect offsets for encryption in all but the first subsample.
Can you please have a look?