### PR TITLE
Updates

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,9 +48,12 @@ add_library(ap4 STATIC ${AP4_SOURCES})
 target_include_directories(ap4 INTERFACE ${AP4_INCLUDE_DIRS})
 
 # Apps
+option(BUILD_APPS "Build example applications" ON)
+if(BUILD_APPS)
 file(GLOB BENTO4_APPS RELATIVE ${SOURCE_ROOT}/Apps ${SOURCE_ROOT}/Apps/*)
 foreach(app ${BENTO4_APPS})
   string(TOLOWER ${app} binary_name)
   add_executable(${binary_name} ${SOURCE_ROOT}/Apps/${app}/${app}.cpp)
   target_link_libraries(${binary_name} ap4)
 endforeach()
+endif(BUILD_APPS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,15 +35,17 @@ else()
   set(AP4_SOURCES ${AP4_SOURCES} ${SOURCE_SYSTEM}/Posix/Ap4PosixRandom.cpp)
 endif()
 
-add_library(ap4 STATIC ${AP4_SOURCES})
-
 # Includes
-include_directories(
+set(AP4_INCLUDE_DIRS
   ${SOURCE_CORE}
   ${SOURCE_CODECS}
   ${SOURCE_CRYPTO}
   ${SOURCE_METADATA}
 )
+include_directories(${AP4_INCLUDE_DIRS})
+
+add_library(ap4 STATIC ${AP4_SOURCES})
+target_include_directories(ap4 INTERFACE ${AP4_INCLUDE_DIRS})
 
 # Apps
 file(GLOB BENTO4_APPS RELATIVE ${SOURCE_ROOT}/Apps ${SOURCE_ROOT}/Apps/*)


### PR DESCRIPTION
* Enable easier integration as a subproject

With this change other CMake subprojects will automatically have access
to the header files and the static library without having to hard-code
any paths.

* Add option not to build example applications

The option is ON by default and does not change current behavior. By
turning it OFF other subprojects can make use of the library without
having to build the example applications.
