### PR TITLE
Fix docker build error due to incorrect dir path

### DIFF
--- a/Build/Docker/Dockerfile
+++ b/Build/Docker/Dockerfile
@@ -10,7 +10,7 @@ RUN apk update && apk add --no-cache ca-certificates bash python3 make cmake gcc
 COPY ./ /tmp/bento4
 
 # Build
-RUN rm -rf /tmp/bento4/cmakebuild && mkdir -p /tmp/bento4/cmakebuild && cd /tmp/bento4/cmakebuild && cmake -DCMAKE_BUILD_TYPE=Release .. && make
+RUN rm -rf /tmp/bento4/cmakebuild && mkdir -p /tmp/bento4/cmakebuild/x86_64-unknown-linux && cd /tmp/bento4/cmakebuild/x86_64-unknown-linux && cmake -DCMAKE_BUILD_TYPE=Release ../.. && make
 
 # Install
 RUN cd /tmp/bento4 && python3 Scripts/SdkPackager.py x86_64-unknown-linux . cmake && mkdir /opt/bento4 && mv /tmp/bento4/SDK/Bento4-SDK-*.x86_64-unknown-linux/* /opt/bento4


### PR DESCRIPTION
Docker build causes the following error.

`Traceback (most recent call last):
  File "Scripts/SdkPackager.py", line 253, in <module>
    CopyFiles(bin_files)
  File "Scripts/SdkPackager.py", line 71, in CopyFiles
    file_list = [os.path.join(source_dir, file) for file in fnmatch.filter(os.listdir(source_dir), pattern)]
FileNotFoundError: [Errno 2] No such file or directory: './cmakebuild/x86_64-unknown-linux/'`

This PR fix the docker build by setting up correct dir path for cmake.

On Dockerfile
From:
`RUN rm -rf /tmp/bento4/cmakebuild && mkdir -p /tmp/bento4/cmakebuild && cd /tmp/bento4/cmakebuild && cmake -DCMAKE_BUILD_TYPE=Release .. && make
`

To:
`RUN rm -rf /tmp/bento4/cmakebuild && mkdir -p /tmp/bento4/cmakebuild/x86_64-unknown-linux && cd /tmp/bento4/cmakebuild/x86_64-unknown-linux && cmake -DCMAKE_BUILD_TYPE=Release ../.. && make`


