### PR TITLE
fix build error.

### DIFF
--- a/Build/Makefiles/Lib.mak
+++ b/Build/Makefiles/Lib.mak
@@ -14,6 +14,7 @@ CORE_SOURCES = 								\
     Ap4AtomSampleTable.cpp                  \
     Ap4AvccAtom.cpp                         \
     Ap4VpccAtom.cpp                         \
+    Ap4Av1cAtom.cpp                         \
     Ap4ByteStream.cpp                       \
     Ap4Co64Atom.cpp                         \
     Ap4ContainerAtom.cpp                    \


### PR DESCRIPTION
Hi, 

I've been faced a build problem with the make command. (on Ubuntu Linux)

Check out below, 
```
commit 3dc8d58b0863b7058fc48a0d6583ffe2ae282ece (HEAD -> master, origin/master, origin/HEAD, fix-make-build)
Merge: 5922ba7 82881bd
Author: Gilles Boccon-Gibod <bok@bok.net>
Date:   Tue Oct 19 15:38:32 2021 -0700

    Merge pull request #654 from nkh-lab/fix-android-ndk

    Add missed AP4_DEFINE_DYNAMIC_CAST_ANCHOR()
```
In Build/Targets/x86_64-unknown-linux the make failed.

I've found the cause and fixed Build/Makefiles/Lib.mak.

Please check the PR.  

Best,