### PR TITLE
fix: mp4encrypt scans and overwrites potentially non NUL-terminated file name (-Wstringop-truncation compilation warning)

### DIFF
--- a/Source/C++/Apps/Mp4Encrypt/Mp4Encrypt.cpp
+++ b/Source/C++/Apps/Mp4Encrypt/Mp4Encrypt.cpp
@@ -709,7 +709,11 @@ main(int argc, char** argv)
             for (AP4_Ordinal i = 0; i < input_fragments.ItemCount(); i++) {
                 // create the input stream
                 char fragment_input_filename[MP4_ENCRYPT_MAX_FILENAME_LENGTH + 1];
-                strncpy(fragment_input_filename, input_fragments[i], sizeof(fragment_input_filename));
+                if (strlen(input_fragments[i]) > MP4_ENCRYPT_MAX_FILENAME_LENGTH) {
+                    fprintf(stderr, "ERROR: input filename too long (%s)\n", input_fragments[i]);
+                    return 1;
+                }
+                strcpy(fragment_input_filename, input_fragments[i]);
                 char* last_dot = strrchr(fragment_input_filename, '.');
                 if (last_dot) {
                     *last_dot = '\0';


### PR DESCRIPTION
`strncpy` used a bound equal to the destination buffer size. As a consequence, an input file name of 2048 chars or more would end up being copied into buffer `fragment_input_filename` without its NUL-terminating character. This could cause stack corruption afterwards (since the buffer is subsequently searched for character '.' and returned pointer is dereferenced to write a `\0` character). This issue was detected by the compiler, through a `-Wstringop-truncation` violation warning.

Proposed fix is to simply reject filenames that don't fit, with NUL-termination, into the buffer and then simply use `strcpy()` to get rid of the warning.