### PR TITLE
A global-buffer-overflow in Ap4ByteStream.cpp:783 as reported on issue 545.

### DIFF
--- a/Source/C++/Core/Ap4HdlrAtom.cpp
+++ b/Source/C++/Core/Ap4HdlrAtom.cpp
@@ -121,23 +121,22 @@ AP4_HdlrAtom::WriteFields(AP4_ByteStream& stream)
     result = stream.WriteUI32(m_Reserved[2]);
     if (AP4_FAILED(result)) return result;
     AP4_UI08 name_size = (AP4_UI08)m_HandlerName.GetLength();
-    if (m_QuickTimeMode) {
-        name_size += 1;
-        if (AP4_FULL_ATOM_HEADER_SIZE + 20 + name_size > m_Size32) {
-            name_size = (AP4_UI08)(m_Size32 - (AP4_FULL_ATOM_HEADER_SIZE + 20));
-        }
-        if (name_size) {
+    if (name_size) {
+        if (m_QuickTimeMode) {
+            name_size += 1;
+            if (AP4_FULL_ATOM_HEADER_SIZE + 20 + name_size > m_Size32) {
+                name_size = (AP4_UI08)(m_Size32 - (AP4_FULL_ATOM_HEADER_SIZE + 20));
+            }
             result = stream.WriteUI08(name_size - 1);
             if (AP4_FAILED(result)) return result;
 
             result = stream.Write(m_HandlerName.GetChars(), name_size - 1);
             if (AP4_FAILED(result)) return result;
         }
-    } else {
-        if (AP4_FULL_ATOM_HEADER_SIZE + 20 + name_size > m_Size32) {
-            name_size = (AP4_UI08)(m_Size32 - (AP4_FULL_ATOM_HEADER_SIZE + 20));
-        }
-        if (name_size) {
+        else {
+            if (AP4_FULL_ATOM_HEADER_SIZE + 20 + name_size > m_Size32) {
+                name_size = (AP4_UI08)(m_Size32 - (AP4_FULL_ATOM_HEADER_SIZE + 20));
+            }
             result = stream.Write(m_HandlerName.GetChars(), name_size);
             if (AP4_FAILED(result)) return result;
         }


### PR DESCRIPTION
If there is no name, do not write any further data to the atom.

Fix for CVE-2021-32265; 
https://github.com/axiomatic-systems/Bento4/issues/545
In an hdlr atom, where the size of the source atom is too short to contain a name, an exception will have occurred because it would try to recalculate the size of the name and end up with an arithmetic overflow.

I checked the Read method above; and that indicates that it is valid for there to be no name. Debugging indicates that the source hdlr is shorter than it should be (for the test file).