### PR TITLE
Add AC4 with immersive stereo (IMS) signaling for DASH

### DIFF
--- a/Source/Python/utils/mp4-dash.py
+++ b/Source/Python/utils/mp4-dash.py
@@ -58,7 +58,8 @@ from mp4utils import (
     MakeNewDir,
     BooleanFromString,
     ReGroupEC3Sets,
-    DolbyDigitalWithMPEGDASHScheme
+    DolbyDigitalWithMPEGDASHScheme,
+    DolbyAc4WithMPEGDASHScheme
 )
 
 # setup main options
@@ -551,7 +552,11 @@ def OutputDash(options, set_attributes, audio_sets, video_sets, subtitles_sets, 
                         scheme_id_uri = DOLBY_DIGITAL_AUDIO_CHANNEL_CONFIGURATION_SCHEME_ID_URI
                 elif audio_track.codec.startswith('ac-4'):
                     audio_channel_config_value = ComputeDolbyAc4AudioChannelConfig(audio_track)
-                    scheme_id_uri = DOLBY_AC4_AUDIO_CHANNEL_CONFIGURATION_SCHEME_ID_URI
+                    (mpeg_scheme, audio_channel_config_value) = DolbyAc4WithMPEGDASHScheme(audio_channel_config_value)
+                    if (mpeg_scheme):
+                        scheme_id_uri = ISO_IEC_23001_8_AUDIO_CHANNEL_CONFIGURATION_SCHEME_ID_URI
+                    else:
+                        scheme_id_uri = DOLBY_AC4_AUDIO_CHANNEL_CONFIGURATION_SCHEME_ID_URI
                 else:
                     # detect the actual number of channels
                     sample_description = audio_track.info['sample_descriptions'][0]
@@ -574,6 +579,12 @@ def OutputDash(options, set_attributes, audio_sets, video_sets, subtitles_sets, 
                                    'SupplementalProperty',
                                    schemeIdUri='tag:dolby.com,2018:dash:EC3_ExtensionComplexityIndex:2018',
                                    value=str(audio_track.complexity_index))
+                # AC-4 IMS SupplementalProperty
+                if audio_track.codec_family == 'ac-4' and audio_track.dolby_ac4_ims == 'Yes':
+                    xml.SubElement(representation,
+                                   'SupplementalProperty',
+                                   schemeIdUri='tag:dolby.com,2016:dash:virtualized_content:2016',
+                                   value='1')
 
                 if options.on_demand:
                     base_url = xml.SubElement(representation, 'BaseURL')

--- a/Source/Python/utils/mp4utils.py
+++ b/Source/Python/utils/mp4utils.py
@@ -453,8 +453,6 @@ class Mp4Track:
                         stream_type = sample_desc['dolby_ac4_info']['presentations'][0]['Stream Type']
                         if stream_type == 'Immersive stereo':
                             self.dolby_ac4_ims = 'Yes'
-                        elif stream_type == 'Channel based immsersive':
-                            self.dolby_ac4_cbi = 'Yes'
                         self.channels = str(self.channels)
                     self.self_contained = sample_desc['dolby_ac4_info']['Self Contained']
 

--- a/Source/Python/utils/mp4utils.py
+++ b/Source/Python/utils/mp4utils.py
@@ -436,12 +436,27 @@ class Mp4Track:
             self.channels = sample_desc['channels']
             # Set the default values for Dolby audio codec flags
             self.dolby_ddp_atmos = 'No'
+            self.dolby_ac4_ims   = 'No'
             if self.codec_family == 'ec-3' and 'dolby_digital_plus_info' in sample_desc:
                 self.channels = GetDolbyDigitalPlusChannels(self)[0]
                 self.dolby_ddp_atmos = sample_desc['dolby_digital_plus_info']['Dolby_Atmos']
                 if (self.dolby_ddp_atmos == 'Yes'):
                     self.complexity_index = sample_desc['dolby_digital_plus_info']['complexity_index']
                     self.channels =  str(self.info['sample_descriptions'][0]['dolby_digital_plus_info']['complexity_index']) + '/JOC'
+            elif self.codec_family == 'ac-4' and 'dolby_ac4_info' in sample_desc:
+                if sample_desc['dolby_ac4_info']['dsi version'] == 0:
+                    raise Exception("AC4 dsi version 0 is deprecated.")
+                elif sample_desc['dolby_ac4_info']['dsi version'] == 1:
+                    if sample_desc['dolby_ac4_info']['bitstream version'] == 0:
+                        raise Exception("AC4 bitstream version 0 is deprecated.")
+                    if len(sample_desc['dolby_ac4_info']['presentations']):
+                        stream_type = sample_desc['dolby_ac4_info']['presentations'][0]['Stream Type']
+                        if stream_type == 'Immersive stereo':
+                            self.dolby_ac4_ims = 'Yes'
+                        elif stream_type == 'Channel based immsersive':
+                            self.dolby_ac4_cbi = 'Yes'
+                        self.channels = str(self.channels)
+                    self.self_contained = sample_desc['dolby_ac4_info']['Self Contained']
 
         self.language = info['language']
         self.language_name = LanguageNames.get(LanguageCodeMap.get(self.language, 'und'), '')
@@ -944,6 +959,22 @@ def ComputeDolbyAc4AudioChannelConfig(track):
                 return '%06x' % presentation['presentation_channel_mask_v1']
 
     return '000000'
+
+# ETSI TS 103 190-2 V1.2.1 (2018-02) Table G.1
+def DolbyAc4WithMPEGDASHScheme(mask):
+    available_mask_dict = {
+        '000002' : '1' , '000001' : '2' , '000003' : '3' , '008003' : '4' ,
+        '000007' : '5' , '000047' : '6' , '020047' : '7' , '008001' : '9' ,
+        '000005' : '10', '008047' : '11', '00004F' : '12', '02FF7F' : '13',
+        '06FF6F' : '13', '000057' : '14', '040047' : '14', '00145F' : '15',
+        '04144F' : '15', '000077' : '16', '040067' : '16', '000A77' : '17',
+        '040A67' : '17', '000A7F' : '18', '040A6F' : '18', '00007F' : '19',
+        '04006F' : '19', '01007F' : '20', '05006F' : '2'}
+    if mask in available_mask_dict:
+        return (True, available_mask_dict[mask])
+    else:
+        return (False, mask)
+
 def ReGroupEC3Sets(audio_sets):
     regroup_audio_sets    = {}
     audio_adaptation_sets = {}

--- a/Source/Python/utils/mp4utils.py
+++ b/Source/Python/utils/mp4utils.py
@@ -975,7 +975,6 @@ def DolbyAc4WithMPEGDASHScheme(mask):
 def ReGroupEC3Sets(audio_sets):
     regroup_audio_sets    = {}
     audio_adaptation_sets = {}
-    sc_index = 1
     for name, audio_tracks in audio_sets.items():
         if audio_tracks[0].codec_family == 'ec-3':
             for track in audio_tracks:

--- a/Source/Python/utils/mp4utils.py
+++ b/Source/Python/utils/mp4utils.py
@@ -454,7 +454,6 @@ class Mp4Track:
                         if stream_type == 'Immersive stereo':
                             self.dolby_ac4_ims = 'Yes'
                         self.channels = str(self.channels)
-                    self.self_contained = sample_desc['dolby_ac4_info']['Self Contained']
 
         self.language = info['language']
         self.language_name = LanguageNames.get(LanguageCodeMap.get(self.language, 'und'), '')
@@ -984,9 +983,6 @@ def ReGroupEC3Sets(audio_sets):
                     adaptation_set_name = ('audio', track.language, track.codec_family, track.channels, 'ATMOS')
                 else:
                     adaptation_set_name = ('audio', track.language, track.codec_family, track.channels)
-                if track.self_contained != 'Yes':
-                    adaptation_set_name = adaptation_set_name + ('#sc' + str(sc_index),)
-                    sc_index += 1
                 adaptation_set = audio_adaptation_sets.get(adaptation_set_name, [])
                 audio_adaptation_sets[adaptation_set_name] = adaptation_set
                 adaptation_set.append(track)


### PR DESCRIPTION
This merge mainly focuses on AC4 including IMS signaling for DASH.  Including following changes,

1. Adding AC4 including IMS stereo for DASH signaling.
2. prefer MPEG scheme for channel configuration if applicable, otherwise choose Dolby.

Also this merge removes unnecessary variable conditions for Dolby Digital Plus.