### PR TITLE
Add Dolby Vision signaling for HLS.

### DIFF
--- a/Source/C++/Apps/Mp4Info/Mp4Info.cpp
+++ b/Source/C++/Apps/Mp4Info/Mp4Info.cpp
@@ -588,9 +588,17 @@ ShowSampleDescription_Text(AP4_SampleDescription& description, bool verbose)
         // Dolby AC-4 specifics
         AP4_Dac4Atom* dac4 = AP4_DYNAMIC_CAST(AP4_Dac4Atom, desc->GetDetails().GetChild(AP4_ATOM_TYPE_DAC4));
         if (dac4) {
+            printf("    Codecs String: ");
+            AP4_String codec;
+            dac4->GetCodecString(codec);
+            printf("%s", codec.GetChars());
+            printf("\n");
+
             const AP4_Dac4Atom::Ac4Dsi& dsi = dac4->GetDsi();
+            printf("    AC-4 dsi version: %d\n", dsi.ac4_dsi_version);
             unsigned short self_contained = 0;
             if (dsi.ac4_dsi_version == 1) {
+                printf("    AC-4 bitstream version: %d\n", dsi.d.v1.bitstream_version);
                 for (unsigned int i = 0; i < dsi.d.v1.n_presentations; i++) {
                     AP4_Dac4Atom::Ac4Dsi::PresentationV1& presentation = dsi.d.v1.presentations[i];
                     if (presentation.presentation_version == 1 || presentation.presentation_version == 2) {
@@ -929,11 +937,12 @@ ShowSampleDescription_Json(AP4_SampleDescription& description, bool verbose)
         if (dac4) {
             printf(",\n");
             printf("\"dolby_ac4_info\": {\n");
-
-            printf("  \"presentations\": [\n");
             const AP4_Dac4Atom::Ac4Dsi& dsi = dac4->GetDsi();
+            printf("  \"dsi version\": %d,\n", dsi.ac4_dsi_version);
             unsigned short self_contained = 0;
             if (dsi.ac4_dsi_version == 1) {
+                printf("  \"bitstream version\": %d,\n", dsi.d.v1.bitstream_version);
+                printf("  \"presentations\": [\n");
                 const char* separator = "";
                 for (unsigned int i = 0; i < dsi.d.v1.n_presentations; i++) {
                     AP4_Dac4Atom::Ac4Dsi::PresentationV1& presentation = dsi.d.v1.presentations[i];

--- a/Source/C++/Apps/Mp4Info/Mp4Info.cpp
+++ b/Source/C++/Apps/Mp4Info/Mp4Info.cpp
@@ -1023,7 +1023,48 @@ ShowSampleDescription_Json(AP4_SampleDescription& description, bool verbose)
         
     // Dolby Vision specifics
     AP4_DvccAtom* dvcc = AP4_DYNAMIC_CAST(AP4_DvccAtom, desc->GetDetails().GetChild(AP4_ATOM_TYPE_DVCC));
+    if(!dvcc) {
+        dvcc = AP4_DYNAMIC_CAST(AP4_DvccAtom, desc->GetDetails().GetChild(AP4_ATOM_TYPE_DVVC));
+    }
     if (dvcc) {
+        /* Codec String */
+        char workspace[64];
+        char coding[5];
+        strncpy(coding, codec.GetChars(), 4);
+        coding[4] = '\0';
+        /* Non back-compatible */
+        if (strcmp(coding, "dvav") == 0 || strcmp(coding, "dva1") == 0 ||
+            strcmp(coding, "dvhe") == 0 || strcmp(coding, "dvh1") == 0){
+            AP4_FormatString(workspace,
+                            sizeof(workspace),
+                            "%s.%02d.%02d",
+                            coding,
+                            dvcc->GetDvProfile(),
+                            dvcc->GetDvLevel());
+            codec = workspace;
+        } else {
+            if (strcmp(coding, "avc1") == 0){
+                strcpy(coding, "dva1");
+            }else if (strcmp(coding, "avc3") == 0){
+                strcpy(coding, "dvav");
+            }else if (strcmp(coding, "hev1") == 0){
+                strcpy(coding, "dvhe");
+            }else if (strcmp(coding, "hvc1") == 0){
+                strcpy(coding, "dvh1");
+            }
+            AP4_FormatString(workspace,
+                            sizeof(workspace),
+                            "%s,%s.%02d.%02d",
+                            codec.GetChars(),
+                            coding,
+                            dvcc->GetDvProfile(),
+                            dvcc->GetDvLevel());
+            codec = workspace;
+        }
+        printf(",\n");
+        printf("\"dv_codecs_string\":\"");
+        printf("%s", codec.GetChars());
+        printf("\"");
         /* Dolby Vision */
         printf(",\n");
         printf("\"dolby_vision\": {\n");

--- a/Source/C++/Codecs/Ap4AvcParser.cpp
+++ b/Source/C++/Codecs/Ap4AvcParser.cpp
@@ -144,7 +144,8 @@ AP4_AvcFrameParser::AP4_AvcFrameParser() :
     m_PrevFrameNum(0),
     m_PrevFrameNumOffset(0),
     m_PrevPicOrderCntMsb(0),
-    m_PrevPicOrderCntLsb(0)
+    m_PrevPicOrderCntLsb(0),
+    m_keepParameterSets(true)
 {
     for (unsigned int i=0; i<256; i++) {
         m_PPS[i] = NULL;

--- a/Source/C++/Codecs/Ap4AvcParser.h
+++ b/Source/C++/Codecs/Ap4AvcParser.h
@@ -293,6 +293,8 @@ public:
                                 unsigned int                  nal_ref_idc,
                                 AP4_AvcSliceHeader&           slice_header);
 
+    void SetParameterControl(bool isKeep) { m_keepParameterSets = isKeep; }
+
 private:
     // methods
     bool SameFrame(unsigned int nal_unit_type_1, unsigned int nal_ref_idc_1, AP4_AvcSliceHeader& sh1,
@@ -322,6 +324,9 @@ private:
     unsigned int                 m_PrevFrameNumOffset;
     int                          m_PrevPicOrderCntMsb;
     unsigned int                 m_PrevPicOrderCntLsb;
+
+    // control if the parameter sets(SPS, PPS) need to be stored in stream('mdat')
+    bool                       m_keepParameterSets;
 };
 
 #endif // _AP4_AVC_PARSER_H_

--- a/Source/C++/Codecs/Ap4HevcParser.h
+++ b/Source/C++/Codecs/Ap4HevcParser.h
@@ -154,6 +154,59 @@ struct AP4_HevcProfileTierLevel {
 };
 
 /*----------------------------------------------------------------------
+|   AP4_HevcVuiParameters
++---------------------------------------------------------------------*/
+struct AP4_HevcVuiParameters {
+  AP4_HevcVuiParameters();
+
+  // methods
+  AP4_Result Parse(AP4_BitReader& bits, unsigned int &transfer_characteristics);
+
+  unsigned int aspect_ratio_info_present_flag;
+  unsigned int aspect_ratio_idc;
+  unsigned int sar_width;
+  unsigned int sar_height;
+  unsigned int overscan_info_present_flag;
+  unsigned int overscan_appropriate_flag;
+  unsigned int video_signal_type_present_flag;
+  unsigned int video_format;
+  unsigned int video_full_range_flag;
+  unsigned int colour_description_present_flag;
+  unsigned int colour_primaries;
+  unsigned int transfer_characteristics;
+  unsigned int matrix_coeffs;
+  //unsigned int chroma_loc_info_present_flag;
+  //unsigned int chroma_sample_loc_type_top_field;
+  //unsigned int chroma_sample_loc_type_bottom_field;
+  //unsigned int neutral_chroma_indication_flag;
+  //unsigned int field_seq_flag;
+  //unsigned int frame_field_info_present_flag;
+  //unsigned int default_display_window_flag;
+  //unsigned int def_disp_win_left_offset;
+  //unsigned int def_disp_win_right_offset;
+  //unsigned int def_disp_win_top_offset;
+  //unsigned int def_disp_win_bottom_offset;
+  //unsigned int vui_timing_info_present_flag;
+  //unsigned int vui_num_units_in_tick;
+  //unsigned int vui_time_scale;
+  //unsigned int vui_poc_proportional_to_timing_flag;
+  //unsigned int vui_num_ticks_poc_diff_one_minus1;
+  //unsigned int vui_hrd_parameters_present_flag;
+
+  //// skip hrd_parameters
+  //unsigned int bitstream_restriction_flag;
+  //unsigned int tiles_fixed_structure_flag;
+  //unsigned int motion_vectors_over_pic_boundaries_flag;
+  //unsigned int restricted_ref_pic_lists_flag;
+  //unsigned int min_spatial_segmentation_idc;
+  //unsigned int max_bytes_per_pic_denom;
+  //unsigned int max_bits_per_min_cu_denom;
+  //unsigned int log2_max_mv_length_horizontal;
+  //unsigned int log2_max_mv_length_vertical;
+};
+
+
+/*----------------------------------------------------------------------
 |   AP4_HevcShortTermRefPicSet
 +---------------------------------------------------------------------*/
 typedef struct {
@@ -268,7 +321,8 @@ struct AP4_HevcSequenceParameterSet {
     unsigned int             num_long_term_ref_pics_sps;
     unsigned int             sps_temporal_mvp_enabled_flag;
     unsigned int             strong_intra_smoothing_enabled_flag;
-    
+    unsigned int             vui_parameters_present_flag;
+    AP4_HevcVuiParameters    vui_parameters;
     AP4_HevcShortTermRefPicSet short_term_ref_pic_sets[AP4_HEVC_SPS_MAX_RPS];
 };
 
@@ -416,6 +470,8 @@ public:
     AP4_HevcVideoParameterSet**    GetVideoParameterSets()    { return &m_VPS[0]; }
     AP4_HevcSequenceParameterSet** GetSequenceParameterSets() { return &m_SPS[0]; }
     AP4_HevcPictureParameterSet**  GetPictureParameterSets()  { return &m_PPS[0]; }
+
+    void SetParameterControl(bool isKeep) { m_keepParameterSets = isKeep; }
     
 private:
     // methods
@@ -441,6 +497,9 @@ private:
     // picture order counting
     unsigned int               m_PrevTid0Pic_PicOrderCntMsb;
     unsigned int               m_PrevTid0Pic_PicOrderCntLsb;
+
+    // control if the parameter sets(VPS, SPS, PPS) need to be stored in stream('mdat')
+    bool                       m_keepParameterSets;
 };
 
 #endif // _AP4_HEVC_PARSER_H_

--- a/Source/C++/Core/Ap4File.h
+++ b/Source/C++/Core/Ap4File.h
@@ -73,6 +73,10 @@ const AP4_UI32 AP4_FILE_BRAND_OPF2 = AP4_ATOM_TYPE('o','p','f','2');
 const AP4_UI32 AP4_FILE_BRAND_AVC1 = AP4_ATOM_TYPE('a','v','c','1');
 const AP4_UI32 AP4_FILE_BRAND_HVC1 = AP4_ATOM_TYPE('h','v','c','1');
 const AP4_UI32 AP4_FILE_BRAND_DBY1 = AP4_ATOM_TYPE('d','b','y','1');
+const AP4_UI32 AP4_FILE_BRAND_DB1P = AP4_ATOM_TYPE('d','b','1','p');
+const AP4_UI32 AP4_FILE_BRAND_DB2G = AP4_ATOM_TYPE('d','b','2','g');
+const AP4_UI32 AP4_FILE_BRAND_DB4H = AP4_ATOM_TYPE('d','b','4','h');
+const AP4_UI32 AP4_FILE_BRAND_DB4G = AP4_ATOM_TYPE('d','b','4','g');
 
 /*----------------------------------------------------------------------
 |   AP4_File

--- a/Source/Python/utils/mp4-dash.py
+++ b/Source/Python/utils/mp4-dash.py
@@ -979,45 +979,61 @@ def OutputHls(options, set_attributes, audio_sets, video_sets, subtitles_sets, s
             iframes_playlist_name = options.hls_iframes_playlist_name
             iframes_playlist_path = media_subdir+'/'+iframes_playlist_name
 
+        supplemental_codec_string = ''
+        if hasattr(video_track, 'supplemental_codec'):
+            if hasattr(video_track, 'dv_brand'):
+                supplemental_codec_string = video_track.supplemental_codec+'/'+video_track.dv_brand
+            else:
+                supplemental_codec_string = video_track.supplemental_codec
+
         if audio_groups:
             # one entry per matching audio group
             for audio_group_name in audio_groups:
                 if '*' not in video_track.hls_group_match and audio_group_name not in video_track.hls_group_match:
                     continue
                 audio_codecs = ','.join(audio_groups[audio_group_name]['codecs'])
-                master_playlist_file.write('#EXT-X-STREAM-INF:{}AUDIO="{}",AVERAGE-BANDWIDTH={:.0f},BANDWIDTH={:.0f},CODECS="{}",RESOLUTION={:.0f}x{:.0f},FRAME-RATE={:.3f}\n'.format(
+                master_playlist_file.write('#EXT-X-STREAM-INF:{}AUDIO="{}",AVERAGE-BANDWIDTH={:.0f},BANDWIDTH={:.0f},VIDEO-RANGE={},CODECS="{}",RESOLUTION={:.0f}x{:.0f},FRAME-RATE={:.3f}\n'.format(
                                            subtitles_group,
                                            audio_group_name,
                                            video_track.average_segment_bitrate + audio_groups[audio_group_name]['average_segment_bitrate'],
                                            video_track.max_segment_bitrate + audio_groups[audio_group_name]['max_segment_bitrate'],
+                                           video_track.video_range,
                                            video_track.codec+','+audio_codecs,
                                            video_track.width,
                                            video_track.height,
                                            video_track.frame_rate))
+                if supplemental_codec_string != '':
+                    master_playlist_file.write(',SUPPLEMENTAL-CODECS="{}"\n'.format(supplemental_codec_string))
                 master_playlist_file.write(media_playlist_path+'\n')
         else:
             # no audio
-            master_playlist_file.write('#EXT-X-STREAM-INF:{}AVERAGE-BANDWIDTH={:.0f},BANDWIDTH={:.0f},CODECS="{}",RESOLUTION={:.0f}x{:.0f},FRAME-RATE={:.3f}\n'.format(
+            master_playlist_file.write('#EXT-X-STREAM-INF:{}AVERAGE-BANDWIDTH={:.0f},BANDWIDTH={:.0f},VIDEO-RANGE={},CODECS="{}",RESOLUTION={:.0f}x{:.0f},FRAME-RATE={:.3f}'.format(
                                        subtitles_group,
                                        video_track.average_segment_bitrate,
                                        video_track.max_segment_bitrate,
+                                       video_track.video_range,
                                        video_track.codec,
                                        video_track.width,
                                        video_track.height,
                                        video_track.frame_rate))
+            if supplemental_codec_string != '':
+                master_playlist_file.write(',SUPPLEMENTAL-CODECS="{}"\n'.format(supplemental_codec_string))
             master_playlist_file.write(media_playlist_path+'\n')
 
         OutputHlsTrack(options, video_track, all_audio_tracks + all_video_tracks, media_subdir, media_playlist_name, media_file_name)
         iframe_average_segment_bitrate,iframe_max_bitrate = OutputHlsIframeIndex(options, video_track, all_audio_tracks + all_video_tracks, media_subdir, iframes_playlist_name, media_file_name)
 
         # this will be written later
-        iframe_playlist_lines.append('#EXT-X-I-FRAME-STREAM-INF:AVERAGE-BANDWIDTH={:.0f},BANDWIDTH={:.0f},CODECS="{}",RESOLUTION={:.0f}x{:.0f},URI="{}"\n'.format(
+        iframe_playlist_lines.append('#EXT-X-I-FRAME-STREAM-INF:AVERAGE-BANDWIDTH={:.0f},BANDWIDTH={:.0f},VIDEO-RANGE={},CODECS="{}",RESOLUTION={:.0f}x{:.0f},URI="{}"'.format(
                                      iframe_average_segment_bitrate,
                                      iframe_max_bitrate,
+                                     video_track.video_range,
                                      video_track.codec,
                                      video_track.width,
                                      video_track.height,
                                      iframes_playlist_path))
+        if supplemental_codec_string != '':
+            iframe_playlist_lines.append(',SUPPLEMENTAL-CODECS="{}"\n'.format(supplemental_codec_string))
 
     master_playlist_file.write('\n# I-Frame Playlists\n')
     master_playlist_file.write(''.join(iframe_playlist_lines))

--- a/Source/Python/utils/mp4utils.py
+++ b/Source/Python/utils/mp4utils.py
@@ -427,24 +427,17 @@ class Mp4Track:
                         brand = 'db1p'
                         if brand in self.parent.info['file']['compatible_brands']:
                             self.dv_brand = brand
-                        else:
-                            print('WARNING: missing brand "db1p" in MP4 file for Dolby Vision Profile 8.1.')
                     elif bl_compatibility_id == 2:
                         self.video_range = 'SDR'
                         brand = 'db2g'
                         if brand in self.parent.info['file']['compatible_brands']:
                             self.dv_brand = brand
-                        else:
-                            print('WARNING: missing brand "db2g" in MP4 file for Dolby Vision Profile x.2.')
                     elif bl_compatibility_id == 4:
                         self.video_range = 'HLG'
-                        self.dv_brand='db4h'
                         if 'db4g' in self.parent.info['file']['compatible_brands']:
                             self.dv_brand = 'db4g'
                         elif 'db4h' in self.parent.info['file']['compatible_brands']:
                             self.dv_brand = 'db4h'
-                        else:
-                            print('WARNING: missing brand "db4g" or "db4h" in MP4 file for Dolby Vision Profile 8.4. Will use "db4h" as default.')
                     else:
                         PrintErrorAndExit('ERROR: unsupported ccid for Dolby Vision profile 8/9.')
                 else:

--- a/Source/Python/utils/mp4utils.py
+++ b/Source/Python/utils/mp4utils.py
@@ -997,7 +997,7 @@ def ReGroupEC3Sets(audio_sets):
     for name, audio_tracks in audio_sets.items():
         if audio_tracks[0].codec_family == 'ec-3':
             for track in audio_tracks:
-                if track.info['sample_descriptions'][0]['dolby_digital_plus_info']['atmos'] == 'Yes':
+                if track.info['sample_descriptions'][0]['dolby_digital_plus_info']['Dolby_Atmos'] == 'Yes':
                     adaptation_set_name = ('audio', track.language, track.codec_family, track.channels, 'ATMOS')
                 else:
                     adaptation_set_name = ('audio', track.language, track.codec_family, track.channels)


### PR DESCRIPTION
1. support 'avc1', 'avc3', 'hvc1', 'hev1' format for MP4 container.
2. add Dolby Vision profile 5,8,9 muxing in MP4 container with additional brands according to _'Dolby Vision Streams Within the ISO Base Media File Format specification, v2.4'_. 
3. improve Dolby Vision sample description for json format.
4. add SUPPLEMENTAL-CODECS and VIDEO-RANGE tags according to https://datatracker.ietf.org/doc/html/draft-pantos-hls-rfc8216bis.

Also fix two bugs for AC4 and DDP,
1. fix AC4 bitstream version bug in Mp4Info.
2. fix Dolby Digital Plus with Atmos variable name typo in python script.