### PR TITLE
fix endian detection to be portable to all gcc archs

### DIFF
--- a/Source/C++/Core/Ap4Config.h
+++ b/Source/C++/Core/Ap4Config.h
@@ -56,7 +56,7 @@
 #if defined(_M_IX86) || defined(_M_X64) || defined(_M_ARM) || defined(_M_ARM64)
 #define AP4_PLATFORM_BYTE_ORDER AP4_PLATFORM_BYTE_ORDER_LITTLE_ENDIAN
 #endif
-#elif defined(__i386__) || defined(__x86_64__) || defined(__arm__) || defined(__arm64__) || defined(__aarch64__)
+#elif defined(__i386__) || defined(__x86_64__) || defined(__arm__) || defined(__arm64__) || defined(__aarch64__) || (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)
 #define AP4_PLATFORM_BYTE_ORDER AP4_PLATFORM_BYTE_ORDER_LITTLE_ENDIAN
 #endif
 #endif


### PR DESCRIPTION
Fix by Steve Langasek fixing buildsin Debian / Ubuntu / other Linux distros on ppc64el.
