### PR TITLE
Fix KeyError: 'atmos'

### DIFF
--- a/Source/Python/utils/mp4utils.py
+++ b/Source/Python/utils/mp4utils.py
@@ -978,7 +978,7 @@ def ReGroupEC3Sets(audio_sets):
     for name, audio_tracks in audio_sets.items():
         if audio_tracks[0].codec_family == 'ec-3':
             for track in audio_tracks:
-                if track.info['sample_descriptions'][0]['dolby_digital_plus_info']['atmos'] == 'Yes':
+                if track.info['sample_descriptions'][0]['dolby_digital_plus_info']['Dolby_Atmos'] == 'Yes':
                     adaptation_set_name = ('audio', track.language, track.codec_family, track.channels, 'ATMOS')
                 else:
                     adaptation_set_name = ('audio', track.language, track.codec_family, track.channels)


### PR DESCRIPTION
Fix error when processing mp4 with DD+ audio but without Dolby Atmos

```
Traceback (most recent call last):
  File "/usr/local/bin/wrappers/../utils/mp4-dash.py", line 2233, in <module>
    main()
  File "/usr/local/bin/wrappers/../utils/mp4-dash.py", line 2211, in main
    OutputDash(options, set_attributes, audio_sets, video_sets, subtitles_sets, subtitles_files)
  File "/usr/local/bin/wrappers/../utils/mp4-dash.py", line 506, in OutputDash
    audio_sets = ReGroupEC3Sets(audio_sets)
  File "/usr/local/bin/utils/mp4utils.py", line 983, in ReGroupEC3Sets
    if track.info['sample_descriptions'][0]['dolby_digital_plus_info']['atmos'] == 'Yes':
```