### PR TITLE
Fix endian detection for powerpc

### DIFF
--- a/Source/C++/Core/Ap4Config.h
+++ b/Source/C++/Core/Ap4Config.h
@@ -50,7 +50,7 @@
 #define AP4_PLATFORM_BYTE_ORDER_LITTLE_ENDIAN 1
 
 #if !defined(AP4_PLATFORM_BYTE_ORDER)
-#if defined(__ppc__)
+#if defined(__ppc__) || defined(__powerpc__)
 #define AP4_PLATFORM_BYTE_ORDER AP4_PLATFORM_BYTE_ORDER_BIG_ENDIAN
 #elif defined(_MSC_VER)
 #if defined(_M_IX86) || defined(_M_X64) || defined(_M_ARM) || defined(_M_ARM64)


### PR DESCRIPTION
This patch has been tested under Debian powerpc GCC 12.0.2