### PR TITLE
fix losing synchronization issue for EC3 due to an unreasonable ReadByte()

### DIFF
--- a/Source/C++/Codecs/Ap4Eac3Parser.cpp
+++ b/Source/C++/Codecs/Ap4Eac3Parser.cpp
@@ -422,7 +422,7 @@ AP4_Eac3Parser::FindHeader(AP4_UI08* header, AP4_Size& skip_size)
             
            return AP4_SUCCESS;
         } else {
-            m_Bits.ReadByte(); // skip
+            m_Bits.SkipBytes(1); // skip
             skip_size++;
         }
     }


### PR DESCRIPTION
Unit-test for fixing this issue,
unsigned char data[] = { 0xb2, 0xd3, 0xa1, 0x0b, 0x77, 0x00, 0xa2, 0x49, 0x24, 0x40 };