### PR TITLE
fix-#772-bug3

### DIFF
--- a/Source/C++/Codecs/Ap4AvcParser.cpp
+++ b/Source/C++/Codecs/Ap4AvcParser.cpp
@@ -1052,6 +1052,7 @@ AP4_AvcFrameParser::Feed(const AP4_UI08* nal_unit,
                                       nal_ref_idc,
                                       *slice_header);
             if (AP4_FAILED(result)) {
+                delete slice_header;
                 return AP4_ERROR_INVALID_FORMAT;
             }
             


### PR DESCRIPTION
This is a fix for memory leak (issue #772 bug3).
Adding the fix, LSAN no longer reports the memory leaks in my environment (Ubuntu 20.04.3 LTS).
I would be happy if this PR is reviewed.
