### PR TITLE
Fix memory leak - delete wrote atoms

### DIFF
--- a/Source/C++/Core/Ap4Processor.cpp
+++ b/Source/C++/Core/Ap4Processor.cpp
@@ -164,6 +164,7 @@ AP4_Processor::ProcessFragments(AP4_MoovAtom*              moov,
         // if this is not a moof atom, just write it back and continue
         if (atom->GetType() != AP4_ATOM_TYPE_MOOF) {
             result = atom->Write(output);
+            delete atom;
             if (AP4_FAILED(result)) return result;
             continue;
         }


### PR DESCRIPTION
`frags.DeleteReferences();` doesn't delete atoms, it's deleting only references. We can't delete atoms just before `DeleteReferences`, because moof atoms are cleared (by `AP4_MovieFragment::~AP4_MovieFragment()`).