### PR TITLE
Added CBCS encryption for DVHE and DVH1 

### DIFF
--- a/Source/C++/Core/Ap4CommonEncryption.cpp
+++ b/Source/C++/Core/Ap4CommonEncryption.cpp
@@ -290,6 +290,8 @@ AP4_CencCbcsSubSampleMapper::AP4_CencCbcsSubSampleMapper(AP4_Size nalu_length_si
         // look for an hevc sample description
         AP4_HvccAtom* hvcc = AP4_DYNAMIC_CAST(AP4_HvccAtom, stsd->FindChild("hvc1/hvcC"));
         if (!hvcc)    hvcc = AP4_DYNAMIC_CAST(AP4_HvccAtom, stsd->FindChild("hev1/hvcC"));
+	if (!hvcc)    hvcc = AP4_DYNAMIC_CAST(AP4_HvccAtom, stsd->FindChild("dvh1/hvcC"));
+	if (!hvcc)    hvcc = AP4_DYNAMIC_CAST(AP4_HvccAtom, stsd->FindChild("dvhe/hvcC"));
         if (!hvcc)    return;
         
         // parse the vps, sps and pps if we have them


### PR DESCRIPTION
Needed to add dvh1 and dvhe in here otherwise it was not possible to package Dolby Vision profile 5 with CBCS