### PR TITLE
Allow use of representation_id instead of language code for subtitle folder

### DIFF
--- a/Source/Python/utils/mp4-dash.py
+++ b/Source/Python/utils/mp4-dash.py
@@ -2226,7 +2226,7 @@ def main():
             MakeNewDir(path.join(options.output_dir, 'subtitles'))
             for subtitles_file in subtitles_files:
                 print('Processing and Copying subtitles file', GetMappedFileName(subtitles_file.media_source.filename))
-                out_dir = path.join(options.output_dir, 'subtitles', subtitles_file.language)
+                out_dir = path.join(options.output_dir, 'subtitles', subtitles_file.representation_id)
                 MakeNewDir(out_dir)
                 media_filename = path.join(out_dir, subtitles_file.media_name)
                 shutil.copyfile(subtitles_file.media_source.filename, media_filename)

--- a/Source/Python/utils/mp4-dash.py
+++ b/Source/Python/utils/mp4-dash.py
@@ -606,7 +606,7 @@ def OutputDash(options, set_attributes, audio_sets, video_sets, subtitles_sets, 
                 xml.SubElement(adaptation_set, 'Role', schemeIdUri='urn:mpeg:dash:role:2011', value='subtitle')
 
                 # see if we have other descriptors
-                AddDescriptor(adaptation_set, set_attributes, 'subtitles/' + subtitles_track.language, 'subtitles')
+                AddDescriptor(adaptation_set, set_attributes, 'subtitles/' + subtitles_track.representation_id, 'subtitles')
 
                 representation = xml.SubElement(adaptation_set,
                                                 'Representation',
@@ -650,7 +650,7 @@ def OutputDash(options, set_attributes, audio_sets, video_sets, subtitles_sets, 
             xml.SubElement(adaptation_set, 'Role', schemeIdUri='urn:mpeg:dash:role:2011', value='subtitle')
 
             # see if we have other descriptors
-            AddDescriptor(adaptation_set, set_attributes, 'subtitles/' + subtitles_file.language, 'subtitles')
+            AddDescriptor(adaptation_set, set_attributes, 'subtitles/' + subtitles_file.representation_id, 'subtitles')
 
             # estimate the bandwidth
             bandwidth = 1024 # default
@@ -659,10 +659,10 @@ def OutputDash(options, set_attributes, audio_sets, video_sets, subtitles_sets, 
 
             representation = xml.SubElement(adaptation_set,
                                             'Representation',
-                                            id='subtitles/'+subtitles_file.language,
+                                            id='subtitles/'+subtitles_file.representation_id,
                                             bandwidth=str(bandwidth))
             base_url = xml.SubElement(representation, 'BaseURL')
-            base_url.text = 'subtitles/'+subtitles_file.language+'/'+subtitles_file.media_name
+            base_url.text = 'subtitles/'+subtitles_file.representation_id+'/'+subtitles_file.media_name
 
     # save the MPD
     if options.mpd_filename:
@@ -1085,7 +1085,7 @@ def OutputHls(options, set_attributes, audio_sets, video_sets, subtitles_sets, s
         presentation_duration = math.ceil(max([track.total_duration for track in all_video_tracks + all_audio_tracks]))
         default_selected = False
         for subtitles_file in subtitles_files:
-            media_subdir = 'subtitles/{}'.format(subtitles_file.language)
+            media_subdir = 'subtitles/{}'.format(subtitles_file.representation_id)
             media_playlist_name = options.hls_media_playlist_name
             default = audio_track.hls_default and not default_selected
             if default:

--- a/Source/Python/utils/subtitles.py
+++ b/Source/Python/utils/subtitles.py
@@ -31,6 +31,8 @@ class SubtitlesFile:
         language_name = LanguageNames.get(self.language, self.language_name)
         self.language_name = media_source.spec.get('+language_name', language_name)
 
+        self.representation_id = media_source.spec.get('+representation_id', self.language)
+
         if media_source.format == 'ttml':
             self.parse_ttml(options)
         elif media_source.format == 'webvtt':


### PR DESCRIPTION
The fallback for when representation_id is not defined is the language code, so this shouldn't be a breaking change.