### PR TITLE
Fix logic of key_info checking

### DIFF
--- a/Source/Python/utils/mp4-dash.py
+++ b/Source/Python/utils/mp4-dash.py
@@ -1200,10 +1200,11 @@ def OutputSmooth(options, audio_tracks, video_tracks):
             xml.SubElement(stream_index, "c", d=str(duration))
 
     if options.playready:
+        key_info = None
         if video_tracks:
             key_info = video_tracks[0].key_info
-            if not key_info and len(audio_tracks):
-                key_info = audio_tracks[0].key_info
+        if not key_info and len(audio_tracks):
+            key_info = audio_tracks[0].key_info
 
         if not key_info:
             return


### PR DESCRIPTION
I noticed in playing around with this tool, that it would produce:

`ERROR: local variable 'key_info' referenced before assignment`

when trying to package a file with both smooth and playready enabled. It looked like a simple error in the logic of this check, and making this edit fixed it for me.