### PR TITLE
Fix Level and BitDepth in AV1 Codec String

### DIFF
--- a/Source/C++/Core/Ap4SampleDescription.cpp
+++ b/Source/C++/Core/Ap4SampleDescription.cpp
@@ -825,7 +825,7 @@ AP4_Av1SampleDescription::AP4_Av1SampleDescription(AP4_UI32        format,
 +---------------------------------------------------------------------*/
 AP4_Result
 AP4_Av1SampleDescription::GetCodecString(AP4_String& codec) {
-    AP4_UI08 bit_depth = 10;
+    AP4_UI08 bit_depth = (this->GetHighBitDepth() == 0) ? 8: (this->GetTwelveBit() == 0 ? 10 : 12);
     AP4_UI08 color_primaries = 1;
     AP4_UI08 transfer_characteristics = 1;
     AP4_UI08 matrix_coefficients = 1;
@@ -838,7 +838,7 @@ AP4_Av1SampleDescription::GetCodecString(AP4_String& codec) {
                      "%s.%d.%02d%c.%02d.%d.%d%d%d.%02d.%02d.%02d.%d",
                      coding,
                      this->GetSeqProfile(),
-                     this->GetSeqLevelIdx0() >> 4,
+                     this->GetSeqLevelIdx0(),
                      this->GetSeqTier0() == 0 ? 'M' : 'H',
                      bit_depth,
                      this->GetMonochrome(),


### PR DESCRIPTION
https://github.com/axiomatic-systems/Bento4/issues/917

The logic of generating codec string for AV1 had a bug. It is giving same Codec String for all the generated manifests. Bitdepth is added as a constant value


**For Bitdepth**
From AV1 Spec (https://aomediacodec.github.io/av1-spec/av1-spec.pdf), Section 5.5.2. Color config syntax 
<img width="748" alt="image" src="https://github.com/axiomatic-systems/Bento4/assets/34328635/c93056b4-4b66-4ccb-a1a9-244a6eaf9736">

We can derive this statements for Bitdepth

If high_bitdepth is 0, then the value for bitdepth is 08. 
If high_bitdepth is 1 and twelve_bit is 0, then the value for bitdepth is 10.
If high_bitdepth is 1 and twelve_bit is 1, then the value for bitdepth is 12.


**For Level**
From AV1 Spec (https://aomediacodec.github.io/av1-spec/av1-spec.pdf), Section Annex A: Profiles and levels, A.3. Levels
Seq Level Index value can be stored for the Level. We need not right shift Seq Level Index by 4 bits
This 2 digit Seq Level Index can be converted to the X.Y format level format, where X = 2 + (seq_level_index >> 2) and Y = seq_level_index & 3

<img width="515" alt="image" src="https://github.com/axiomatic-systems/Bento4/assets/34328635/5c4b1122-0b42-4386-9df9-e25548d8a614">



