### PR TITLE
Fix overflow issues found by fuzzer

### DIFF
--- a/Source/C++/Core/Ap4IproAtom.cpp
+++ b/Source/C++/Core/Ap4IproAtom.cpp
@@ -62,6 +62,10 @@ AP4_IproAtom::AP4_IproAtom(AP4_UI32         size,
                            AP4_AtomFactory& atom_factory) :
     AP4_ContainerAtom(AP4_ATOM_TYPE_IPRO, size, false, version, flags)
 {
+    if (size < AP4_FULL_ATOM_HEADER_SIZE + 2) {
+        return;
+    }
+
     // read the number of entries
     AP4_UI16 entry_count;
     stream.ReadUI16(entry_count);

--- a/Source/C++/Core/Ap4Marlin.cpp
+++ b/Source/C++/Core/Ap4Marlin.cpp
@@ -1116,10 +1116,11 @@ AP4_MkidAtom::AP4_MkidAtom(AP4_Size        size,
                            AP4_ByteStream& stream) :
     AP4_Atom(AP4_ATOM_TYPE_MKID, size, version, flags)
 {
+    if (size < AP4_FULL_ATOM_HEADER_SIZE+4) return;
     AP4_Size available = size-(AP4_FULL_ATOM_HEADER_SIZE+4);
     AP4_UI32 entry_count = 0;
     stream.ReadUI32(entry_count);
-    if (available < entry_count*(16+4)) return;
+    if (available < (AP4_UI64)entry_count*(16+4)) return;
     m_Entries.SetItemCount(entry_count);
     for (unsigned int i=0; i<entry_count && available >= 16+4; i++) {
         AP4_UI32 entry_size;

--- a/Source/C++/Core/Ap4SaioAtom.cpp
+++ b/Source/C++/Core/Ap4SaioAtom.cpp
@@ -107,7 +107,7 @@ AP4_SaioAtom::AP4_SaioAtom(AP4_UI32        size,
     AP4_Result result = stream.ReadUI32(entry_count);
     if (AP4_FAILED(result)) return;
     remains -= 4;
-    if (remains < entry_count*(m_Version==0?4:8)) {
+    if (remains < (AP4_UI64)entry_count*(m_Version==0?4:8)) {
         return;
     }
     m_Entries.SetItemCount(entry_count);


### PR DESCRIPTION
Fuzzer had caught a number of large malloc and these large malloc were caused by overflow of AP4_UI32 causing the validation logic to be skipped.