### PR TITLE
Fix Smooth Streaming Client Manifest URLs

### DIFF
--- a/Source/Python/utils/mp4-dash.py
+++ b/Source/Python/utils/mp4-dash.py
@@ -1119,11 +1119,7 @@ def OutputSmooth(options, audio_tracks, video_tracks):
 
     # process the audio tracks
     for audio_track in audio_tracks:
-        stream_name = audio_track.label
-        if stream_name == '':
-            stream_name = audio_track.language_name
-        if stream_name == '' or stream_name == 'Unknown':
-            stream_name = "audio_"+audio_track.language
+        stream_name = "audio_"+audio_track.language
         audio_url_pattern="QualityLevels({bitrate})/Fragments(%s={start time})" % (stream_name)
         stream_index = xml.SubElement(client_manifest,
                                       'StreamIndex',


### PR DESCRIPTION
Partially revert track label support for Smooth Streaming [4916daf0efeed8632d10d0bf758f705450d51e8c]

trackName in server manifest and part of the client manifest StreamIndex URL should match. Also using arbitrary UTF-8 in language_name as part of the URL should be avoided