### PR TITLE
fix edit list duration typo for AC3, EC3 and AC4.

### DIFF
--- a/Source/C++/Apps/Mp4Mux/Mp4Mux.cpp
+++ b/Source/C++/Apps/Mp4Mux/Mp4Mux.cpp
@@ -667,7 +667,7 @@ AddAc3Track(AP4_Movie&             movie,
         if (!movie.GetTimeScale()) {
             duration = sample_count * 1536;
         } else {
-            duration = AP4_ConvertTime(1000*sample_table->GetSampleCount(), sample_rate, movie.GetTimeScale());
+            duration = AP4_ConvertTime(1536*sample_table->GetSampleCount(), sample_rate, movie.GetTimeScale());
         }
         AP4_ElstEntry new_elst_entry = AP4_ElstEntry(duration, 0, 1);
         new_elst->AddEntry(new_elst_entry);
@@ -814,7 +814,7 @@ AddEac3Track(AP4_Movie&             movie,
         if (!movie.GetTimeScale()) {
             duration = sample_count * 1536;
         } else {
-            duration = AP4_ConvertTime(1000*sample_table->GetSampleCount(), sample_rate, movie.GetTimeScale());
+            duration = AP4_ConvertTime(1536*sample_table->GetSampleCount(), sample_rate, movie.GetTimeScale());
         }
         AP4_ElstEntry new_elst_entry = AP4_ElstEntry(duration, 0, 1);
         new_elst->AddEntry(new_elst_entry);
@@ -962,7 +962,7 @@ AddAc4Track(AP4_Movie&            movie,
         if (!movie.GetTimeScale()) {
             duration = AP4_UI64(sample_count) * sample_duration;
         } else {
-            duration = AP4_ConvertTime(1000*sample_table->GetSampleCount(), media_time_scale, movie.GetTimeScale());
+            duration = AP4_ConvertTime(AP4_UI64(sample_count)*sample_table->GetSampleCount(), media_time_scale, movie.GetTimeScale());
         }
         AP4_ElstEntry new_elst_entry = AP4_ElstEntry(duration, 0, 1);
         new_elst->AddEntry(new_elst_entry);


### PR DESCRIPTION
Fix sample duration typo for AC3 and EC3. For AC4, directly use sample duration.