### PR TITLE
Some improvements CMAKE_OSX_ARCHITECTURES / codec class subclassing / AP4_FragmentSampleTable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,13 @@ function(get_bento4_version)
 endfunction()
 
 get_bento4_version()
-set(CMAKE_OSX_ARCHITECTURES "arm64;x86_64" CACHE STRING "")
+
+option(USE_DEFAULT_OSX_ARCHITECTURES "Build bento4 by default for arm64, x86_64 OSX architectures" ON)
+
+if(USE_DEFAULT_OSX_ARCHITECTURES)
+  set(CMAKE_OSX_ARCHITECTURES "arm64;x86_64" CACHE STRING "")
+endif()
+
 project(bento4 VERSION "${BENTO4_VERSION}")
 
 # Variables

--- a/Source/C++/Codecs/Ap4Ac3Parser.h
+++ b/Source/C++/Codecs/Ap4Ac3Parser.h
@@ -111,7 +111,7 @@ public:
     AP4_Size   GetBytesFree();
     AP4_Size   GetBytesAvailable();
     
-private:
+protected:
     // methods
     AP4_Result FindHeader(AP4_UI08* header);
     

--- a/Source/C++/Codecs/Ap4Ac4Parser.h
+++ b/Source/C++/Codecs/Ap4Ac4Parser.h
@@ -129,7 +129,7 @@ public:
     AP4_Size   GetBytesFree();
     AP4_Size   GetBytesAvailable();
 
-private:
+protected:
     // methods
     AP4_Result FindHeader(AP4_UI08* header);
     AP4_UI32   GetSyncFrameSize(AP4_BitReader &bits);

--- a/Source/C++/Codecs/Ap4AdtsParser.h
+++ b/Source/C++/Codecs/Ap4AdtsParser.h
@@ -110,7 +110,7 @@ public:
     AP4_Size   GetBytesFree();
     AP4_Size   GetBytesAvailable();
 
-private:
+protected:
     // methods
     AP4_Result FindHeader(AP4_UI08* header);
 

--- a/Source/C++/Codecs/Ap4Eac3Parser.h
+++ b/Source/C++/Codecs/Ap4Eac3Parser.h
@@ -112,7 +112,7 @@ public:
     AP4_Size   GetBytesFree();
     AP4_Size   GetBytesAvailable();
 
-private:
+protected:
     // methods
     AP4_Result FindHeader(AP4_UI08* header, AP4_Size& skip_size);
 

--- a/Source/C++/Core/Ap4FragmentSampleTable.cpp
+++ b/Source/C++/Core/Ap4FragmentSampleTable.cpp
@@ -291,10 +291,19 @@ AP4_FragmentSampleTable::GetSampleChunkPosition(AP4_Ordinal  sample_index,
 |   AP4_FragmentSampleTable::GetSampleIndexForTimeStamp
 +---------------------------------------------------------------------*/
 AP4_Result 
-AP4_FragmentSampleTable::GetSampleIndexForTimeStamp(AP4_UI64     /*ts*/, 
+AP4_FragmentSampleTable::GetSampleIndexForTimeStamp(AP4_UI64 ts, 
                                                     AP4_Ordinal& sample_index)
 {
-    sample_index = 0; // TODO
+    if (!m_Samples.ItemCount())
+        return AP4_ERROR_NOT_ENOUGH_DATA;
+
+    sample_index = 0;
+    while (sample_index < m_Samples.ItemCount() && m_Samples[sample_index].GetCts() + m_Samples[sample_index].GetDuration() < ts)
+        ++sample_index;
+
+    if (sample_index == m_Samples.ItemCount())
+        return AP4_ERROR_NOT_ENOUGH_DATA;
+
     return AP4_SUCCESS;
 }
 
@@ -302,8 +311,16 @@ AP4_FragmentSampleTable::GetSampleIndexForTimeStamp(AP4_UI64     /*ts*/,
 |   AP4_FragmentSampleTable::GetNearestSyncSampleIndex
 +---------------------------------------------------------------------*/
 AP4_Ordinal  
-AP4_FragmentSampleTable::GetNearestSyncSampleIndex(AP4_Ordinal /*sample_index*/, bool /*before*/)
+AP4_FragmentSampleTable::GetNearestSyncSampleIndex(AP4_Ordinal sample_index, bool before)
 {
-    return 0; // TODO
+    if (sample_index >= m_Samples.ItemCount())
+        return sample_index;
+
+    AP4_Ordinal end(before ? 0 : m_Samples.ItemCount());
+
+    while (sample_index != end && !m_Samples[sample_index].IsSync())
+        sample_index = sample_index + (before ? -1 : 1);
+
+    return sample_index;
 }
 


### PR DESCRIPTION
i choosen propose to send some less invasive changes from our custom bento4 in the hoping will be reviewed cc @barbibulle

commit 1:
`CMAKE_OSX_ARCHITECTURES` has been hardcoded, this lead to problems when you dont need to change it, at least on our build system dont need it, and this cause build failures.

my solution proposal is allow use of new bool: `USE_DEFAULT_OSX_ARCHITECTURES`
to allow to avoid set the default values
example: `-DUSE_DEFAULT_OSX_ARCHITECTURES=OFF`
the previous behaviour is kept without changes, but allow to disable it
fix #945

commit 2:
as title implement GetSampleIndexForTimeStamp/GetNearestSyncSampleIndex methods

commit 3:
allow codec audio parsers classes to be inherited, and that subclasses can access to private data/methods

