### PR TITLE
Check `__PPC__` and `__PPC` macros

### DIFF
--- a/Source/C++/Core/Ap4Config.h
+++ b/Source/C++/Core/Ap4Config.h
@@ -50,7 +50,7 @@
 #define AP4_PLATFORM_BYTE_ORDER_LITTLE_ENDIAN 1
 
 #if !defined(AP4_PLATFORM_BYTE_ORDER)
-#if defined(__ppc__) || defined(__powerpc__)
+#if defined(__ppc__) || defined(__powerpc__) || defined(__PPC__) || defined(__PPC)
 #define AP4_PLATFORM_BYTE_ORDER AP4_PLATFORM_BYTE_ORDER_BIG_ENDIAN
 #elif defined(_MSC_VER)
 #if defined(_M_IX86) || defined(_M_X64) || defined(_M_ARM) || defined(_M_ARM64)


### PR DESCRIPTION
Required for detecting PowerPC on some compilers