### PR TITLE
Cleanup Widevine PSSH

### DIFF
--- a/Source/Python/utils/mp4utils.py
+++ b/Source/Python/utils/mp4utils.py
@@ -1296,9 +1296,6 @@ def ComputeWidevineHeader(header_spec, encryption_scheme, kid_hex):
     if 'policy' in fields:
         protobuf_fields.append((6, fields['policy']))
 
-    if encryption_scheme == 'cenc':
-        protobuf_fields.append((1, 1))
-
     four_cc = struct.unpack('>I', encryption_scheme.encode('ascii'))[0]
     protobuf_fields.append((9, four_cc))
 


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/8c007b87-5f80-4494-b75d-28eb7ce658b4)
https://tools.axinom.com/decoders/PsshBox

Remove deprecated Algorithm field 1 which should not be used conjunction with Protection Scheme field 9

If backward compatibility is needed please consider using the Algorithm field only for CENC instead, e.g.
```
if encryption_scheme == 'cenc':
    protobuf_fields.append((1, 1))
else:
    four_cc = struct.unpack('>I', encryption_scheme.encode('ascii'))[0]
    protobuf_fields.append((9, four_cc))
```