### PR TITLE
Fix quote import in python 3.13

### DIFF
--- a/Source/Python/utils/mp4-dash-encode.py
+++ b/Source/Python/utils/mp4-dash-encode.py
@@ -2,8 +2,11 @@
 
 from optparse import OptionParser
 from subprocess import check_output, CalledProcessError
-from pipes import quote
 import sys
+if not sys.version_info < (3, 13):
+    from shlex import quote
+else:
+    from pipes import quote
 import os
 import os.path as path
 import json


### PR DESCRIPTION
The pipes module is removed in the latest python version