### PR TITLE
Update Ap4CommonEncryption.cpp

### DIFF
--- a/Source/C++/Core/Ap4CommonEncryption.cpp
+++ b/Source/C++/Core/Ap4CommonEncryption.cpp
@@ -3277,7 +3277,11 @@ AP4_CencSampleEncryption::AP4_CencSampleEncryption(AP4_Atom&       outer,
     
     stream.ReadUI32(m_SampleInfoCount);
 
-    AP4_Size payload_size = size-m_Outer.GetHeaderSize()-4;
+    /* Prevent the payload_size from becoming negative to avoid overflow */
+    AP4_Size payload_size = 0;
+    if(size > (m_Outer.GetHeaderSize() + 4))
+	payload_size = size - m_Outer.GetHeaderSize() - 4;
+    
     m_SampleInfos.SetDataSize(payload_size);
     stream.Read(m_SampleInfos.UseData(), payload_size);
 }


### PR DESCRIPTION
Verify payload_size in AP4_CencSampleEncryption() to fix heap-overflow in Ap4ByteStream.cpp:785.

#1021
#990 
#989 -bug2 
#951 
#939 -bug2
#789 
#705 
#641 

this patch will lead to reach an abort at Ap4Atom.cpp:763.
```
mp4edit: /src/Bento4/Source/C++/Core/Ap4Atom.cpp:763: virtual AP4_Result AP4_AtomListWriter::Action(AP4_Atom *) const: Assertion `bytes_written <= atom->GetSize()' failed.
 ```
 
 I don't think Ap4Atom.cpp:763 is a vulnerability, but rather an acceptable abort.