### PR TITLE
Add Subsample Encryption Support for Dolby AC-4

### DIFF
--- a/Source/C++/Codecs/Ap4Ac4Parser.cpp
+++ b/Source/C++/Codecs/Ap4Ac4Parser.cpp
@@ -36,26 +36,31 @@ bool AP4_Ac4Header::m_DeprecatedV0 = true;
 /*----------------------------------------------------------------------+
 |    AP4_Ac4Header::AP4_Ac4Header
 +----------------------------------------------------------------------*/
-AP4_Ac4Header::AP4_Ac4Header(const AP4_UI08* bytes, unsigned int size)
+AP4_Ac4Header::AP4_Ac4Header(const AP4_UI08* bytes, unsigned int size, bool header_exists)
 {
     /* Read the entire the frame */
     AP4_BitReader bits(bytes, size);
 
-    m_SyncWord = bits.ReadBits(16);
-    m_HeaderSize = 2;
-    if (m_SyncWord == AP4_AC4_SYNC_WORD_CRC){
-        m_CrcSize = 2;
-    }else {
-        m_CrcSize = 0;
-    }
-    m_FrameSize = bits.ReadBits(16);
-    m_HeaderSize += 2;
-    if (m_FrameSize == 0xFFFF){
-        m_FrameSize = bits.ReadBits(24);
-        m_HeaderSize += 3; 
+    /* Sync word and frame_size()*/
+    if (header_exists) {
+        m_SyncWord = bits.ReadBits(16);
+        m_HeaderSize = 2;
+        if (m_SyncWord == AP4_AC4_SYNC_WORD_CRC){
+            m_CrcSize = 2;
+        }else {
+            m_CrcSize = 0;
+        }
+        m_FrameSize = bits.ReadBits(16);
+        m_HeaderSize += 2;
+        if (m_FrameSize == 0xFFFF){
+            m_FrameSize = bits.ReadBits(24);
+            m_HeaderSize += 3;
+        }
     }
 
     /* Begin to parse TOC */
+    AP4_Position tocStart = bits.GetBitsPosition() / 8;
+
     m_BitstreamVersion = bits.ReadBits(2);
     if (m_BitstreamVersion == 3) {
         m_BitstreamVersion = AP4_Ac4VariableBits(bits, 2);
@@ -168,31 +173,40 @@ AP4_Ac4Header::AP4_Ac4Header(const AP4_UI08* bytes, unsigned int size)
                 m_PresentationV1[pres_idx].d.v1.dolby_atmos_indicator |= m_PresentationV1[pres_idx].d.v1.substream_groups[sg].d.v1.dolby_atmos_indicator;
             }
         }
-        delete [] substream_groups;
+        delete[] substream_groups;
 
         if (bObjorAjoc == 0){
             m_ChannelCount = AP4_Ac4ChannelCountFromSpeakerGroupIndexMask(speakerGroupIndexMask);
         }else {
-            m_ChannelCount = channelCount;
+            m_ChannelCount = 2;
         }
     }
-}
 
-AP4_Ac4Header::~AP4_Ac4Header()
-{
-    if (m_PresentationV1) {
-        assert(m_PresentationV1 != NULL);
-        for (unsigned int pres_idx = 0; pres_idx < m_NPresentations; pres_idx++) {
-            assert(m_PresentationV1[pres_idx].d.v1.substream_groups != NULL);
-            for (int j = 0; j < m_PresentationV1[pres_idx].d.v1.n_substream_groups; j++)
-                delete[] m_PresentationV1[pres_idx].d.v1.substream_groups[j].d.v1.substreams;
-            delete[] m_PresentationV1[pres_idx].d.v1.substream_groups;
-            delete[] m_PresentationV1[pres_idx].d.v1.substream_group_indexs;
-        }
-        delete[] m_PresentationV1;
+    // substream_index_table
+    AP4_UI32 n_substreams = bits.ReadBits(2);
+    if (n_substreams == 0) {
+        n_substreams = AP4_Ac4VariableBits(bits, 2) + 4;
     }
+    AP4_UI08 b_size_present;
+    if (n_substreams == 1) {
+        b_size_present = bits.ReadBit();
+    } else {
+        b_size_present = 1;
+    }
+    if (b_size_present) {
+        for (AP4_UI32 s = 0; s < n_substreams; s++) {
+            AP4_UI08 b_more_bits = bits.ReadBit();
+            AP4_UI32 substream_size = bits.ReadBits(10);
+            if (b_more_bits) {
+                substream_size += (AP4_Ac4VariableBits(bits, 2) << 10);
+            }
+        }
+    }
+    if (bits.GetBitsPosition() % 8) {
+        bits.SkipBits(8 - (bits.GetBitsPosition() % 8));
+    }
+    m_TocSize = bits.GetBitsPosition() / 8 - tocStart;
 }
-
 
 /*----------------------------------------------------------------------+
 |    AP4_Ac4Header::MatchFixed
@@ -368,7 +382,7 @@ AP4_Result
 AP4_Ac4Parser::FindFrame(AP4_Ac4Frame& frame)
 {
     unsigned int   available;
-    unsigned char  raw_header[AP4_AC4_HEADER_SIZE];
+    unsigned char  *raw_header = new unsigned char[AP4_AC4_HEADER_SIZE];
     AP4_Result     result;
 
     /* align to the start of the next byte */
@@ -385,6 +399,8 @@ AP4_Ac4Parser::FindFrame(AP4_Ac4Frame& frame)
         return AP4_ERROR_NOT_ENOUGH_DATA;
     }
 
+    delete[] raw_header;
+    raw_header = new unsigned char[sync_frame_size];
     /*
      * Error handling to skip the 'fake' sync word. 
      * - the maximum sync frame size is about (AP4_BITSTREAM_BUFFER_SIZE - 1) bytes.
@@ -396,15 +412,10 @@ AP4_Ac4Parser::FindFrame(AP4_Ac4Frame& frame)
         }
         return AP4_ERROR_NOT_ENOUGH_DATA;
     }
-
-    unsigned char *rawframe = new unsigned char[sync_frame_size];
-
     // copy the whole frame becasue toc size is unknown
-    m_Bits.PeekBytes(rawframe, sync_frame_size);
+    m_Bits.PeekBytes(raw_header, sync_frame_size);
     /* parse the header */
-    AP4_Ac4Header ac4_header(rawframe, sync_frame_size);
-
-    delete[] rawframe;
+    AP4_Ac4Header ac4_header(raw_header, sync_frame_size);
 
     // Place before goto statement to resolve Xcode compiler issue
     unsigned int bit_rate_mode = 0;
@@ -421,33 +432,31 @@ AP4_Ac4Parser::FindFrame(AP4_Ac4Frame& frame)
     // TODO: find the proper AP4_AC4_MAX_TOC_SIZE or just parse what this step need ?
     if (available >= ac4_header.m_FrameSize + ac4_header.m_HeaderSize + ac4_header.m_CrcSize + AP4_AC4_HEADER_SIZE + AP4_AC4_MAX_TOC_SIZE) {
         // enough to peek at the header of the next frame
+        unsigned char *peek_raw_header = new unsigned char[AP4_AC4_HEADER_SIZE];
 
         m_Bits.SkipBytes(ac4_header.m_FrameSize + ac4_header.m_HeaderSize + ac4_header.m_CrcSize);
-        m_Bits.PeekBytes(raw_header, AP4_AC4_HEADER_SIZE);
+        m_Bits.PeekBytes(peek_raw_header, AP4_AC4_HEADER_SIZE);
 
         // duplicated work, just to get the frame size
-        AP4_BitReader peak_tmp_bits(raw_header, AP4_AC4_HEADER_SIZE);
-        unsigned int next_sync_frame_size = GetSyncFrameSize(peak_tmp_bits);
+        AP4_BitReader peak_tmp_bits(peek_raw_header, AP4_AC4_HEADER_SIZE);
+        unsigned int peak_sync_frame_size = GetSyncFrameSize(peak_tmp_bits);
 
-        unsigned char *next_rawframe = new unsigned char[next_sync_frame_size];
-
+        delete[] peek_raw_header;
+        peek_raw_header = new unsigned char[peak_sync_frame_size];
         // copy the whole frame becasue toc size is unknown
-        if (m_Bits.GetBytesAvailable() < (next_sync_frame_size)) {
-            next_sync_frame_size = m_Bits.GetBytesAvailable();
+        if (m_Bits.GetBytesAvailable() < (peak_sync_frame_size)) {
+            peak_sync_frame_size = m_Bits.GetBytesAvailable();
         }
-        m_Bits.PeekBytes(next_rawframe, next_sync_frame_size);
+        m_Bits.PeekBytes(peek_raw_header, peak_sync_frame_size);
 
         m_Bits.SkipBytes(-((int)(ac4_header.m_FrameSize + ac4_header.m_HeaderSize + ac4_header.m_CrcSize)));
 
         /* check the header */
-        AP4_Ac4Header peek_ac4_header(next_rawframe, next_sync_frame_size);
-
-        delete[] next_rawframe;
-
+        AP4_Ac4Header peek_ac4_header(peek_raw_header, peak_sync_frame_size, true);
         result = peek_ac4_header.Check();
         if (AP4_FAILED(result)) {
             // TODO: need to reserve current sync frame ?
-            m_Bits.SkipBytes(sync_frame_size + next_sync_frame_size);
+            m_Bits.SkipBytes(sync_frame_size + peak_sync_frame_size);
             goto fail;
         }
 
@@ -455,7 +464,7 @@ AP4_Ac4Parser::FindFrame(AP4_Ac4Frame& frame)
         /* fixed part of the previous header                           */
         if (!AP4_Ac4Header::MatchFixed(ac4_header, peek_ac4_header)) {
             // TODO: need to reserve current sync frame ?
-            m_Bits.SkipBytes(sync_frame_size + next_sync_frame_size);
+            m_Bits.SkipBytes(sync_frame_size + peak_sync_frame_size);
             goto fail;
         }
     } else if (available < (ac4_header.m_FrameSize + ac4_header.m_HeaderSize + ac4_header.m_CrcSize) || (m_Bits.m_Flags & AP4_BITSTREAM_FLAG_EOS) == 0) {

--- a/Source/C++/Codecs/Ap4Ac4Parser.h
+++ b/Source/C++/Codecs/Ap4Ac4Parser.h
@@ -50,9 +50,7 @@
 class AP4_Ac4Header {
 public:
     // constructor
-    AP4_Ac4Header(const AP4_UI08* bytes, unsigned int size);
-    // destructor
-    ~AP4_Ac4Header();
+    AP4_Ac4Header(const AP4_UI08* bytes, unsigned int size, bool header_exists=true);
     
     // methods
     AP4_Result Check();
@@ -84,6 +82,7 @@ public:
     AP4_UI32 m_ShortProgramId;
     AP4_UI32 m_BProgramUuidPresent;
     AP4_Byte m_ProgramUuid[16];
+    AP4_UI32 m_TocSize;
 
     static bool m_DeprecatedV0;
 

--- a/Source/C++/Core/Ap4CommonEncryption.cpp
+++ b/Source/C++/Core/Ap4CommonEncryption.cpp
@@ -53,6 +53,7 @@
 #include "Ap4PsshAtom.h"
 #include "Ap4AvcParser.h"
 #include "Ap4HevcParser.h"
+#include "Ap4Ac4Parser.h"
 
 /*----------------------------------------------------------------------
 |   constants
@@ -107,7 +108,16 @@ AP4_CencBasicSubSampleMapper::GetSubSampleMap(AP4_DataBuffer&      sample_data,
     
     // process the sample data, one NALU at a time
     const AP4_UI08* in_end = sample_data.GetData()+sample_data.GetDataSize();
-    while ((AP4_Size)(in_end-in) > 1+m_NaluLengthSize) {
+    if (m_Format == AP4_SAMPLE_FORMAT_AC_4) {
+        AP4_Ac4Header ac4_header(in, (AP4_Size)(in_end - in), false);
+        // BytesOfProtectedData shall be adjusted to a multiple of 16 bytes for 'cbc1'
+        AP4_Size encrypted_size = ((AP4_Size)(in_end - in) - ac4_header.m_TocSize)/16*16;
+        AP4_Size cleartext_size = (AP4_Size)(in_end - in) - encrypted_size;
+        bytes_of_cleartext_data.Append(cleartext_size);
+        bytes_of_encrypted_data.Append(encrypted_size);
+        return AP4_SUCCESS;
+    }
+    while ((AP4_Size)(in_end-in) > m_NaluLengthSize) {
         unsigned int nalu_length;
         switch (m_NaluLengthSize) {
             case 1:
@@ -159,6 +169,18 @@ AP4_CencAdvancedSubSampleMapper::GetSubSampleMap(AP4_DataBuffer&      sample_dat
     
     // process the sample data, one NALU at a time
     const AP4_UI08* in_end = sample_data.GetData()+sample_data.GetDataSize();
+    if (m_Format == AP4_SAMPLE_FORMAT_AC_4) {
+        // According to ISO/IEC 23001-7 2023-8, BytesOfProtectedData shall be adjusted to a multiple of 16 bytes for 'cens' and 'cenc' mode.
+        AP4_Ac4Header ac4_header(in, (AP4_Size)(in_end - in), false);
+        AP4_Size total = static_cast<AP4_Size>(in_end - in);
+        AP4_Size header_size = ac4_header.m_TocSize;
+        AP4_Size encrypt_size = total - header_size;
+
+        AP4_Size tail = encrypt_size & 0xF;   
+        bytes_of_cleartext_data.Append(header_size + tail);
+        bytes_of_encrypted_data.Append(encrypt_size - tail);
+        return AP4_SUCCESS;
+    }
     while ((AP4_Size)(in_end-in) > 1+m_NaluLengthSize) {
         unsigned int nalu_length;
         switch (m_NaluLengthSize) {
@@ -363,6 +385,21 @@ AP4_CencCbcsSubSampleMapper::GetSubSampleMap(AP4_DataBuffer&      sample_data,
     
     // process the sample data, one NALU at a time
     const AP4_UI08* in_end = sample_data.GetData()+sample_data.GetDataSize();
+    if (m_Format == AP4_SAMPLE_FORMAT_AC_4) {
+        AP4_Ac4Header ac4_header(in, (AP4_Size)(in_end - in), false);
+        // BytesOfProtectedData is not adjusted to a multiple of 16 bytes for 'cbcs' according
+        // to ISO/IEC 23001-7 2023-8, however decryption model doesn't support in Bento4, need
+        // to revisit this code in future.
+        // bytes_of_cleartext_data.Append(ac4_header.m_TocSize);
+        // bytes_of_encrypted_data.Append((AP4_Size)(in_end - in) - ac4_header.m_TocSize);
+        // BytesOfProtectedData shall be adjusted to a multiple of 16 bytes for 'cbc1'
+        AP4_Size encrypted_size = ((AP4_Size)(in_end - in) - ac4_header.m_TocSize) / 16 * 16;
+        AP4_Size cleartext_size = (AP4_Size)(in_end - in) - encrypted_size;
+        bytes_of_cleartext_data.Append(cleartext_size);
+        bytes_of_encrypted_data.Append(encrypted_size);
+        return AP4_SUCCESS;
+    }
+
     while ((AP4_Size)(in_end-in) > 1+m_NaluLengthSize) {
         unsigned int nalu_length;
         switch (m_NaluLengthSize) {
@@ -1562,7 +1599,7 @@ AP4_CencEncryptingProcessor::CreateTrackHandler(AP4_TrakAtom* trak)
             if (m_Options & OPTION_IV_SIZE_8) {
                 cipher_iv_size = 8;
             }
-            if (enc_format == AP4_ATOM_TYPE_ENCV) {
+            if (enc_format == AP4_ATOM_TYPE_ENCV || (enc_format == AP4_ATOM_TYPE_ENCA && format == AP4_ATOM_TYPE_AC_4)) {
                 crypt_byte_block = 1;
                 skip_byte_block  = 9;
             }
@@ -1594,7 +1631,7 @@ AP4_CencEncryptingProcessor::CreateTrackHandler(AP4_TrakAtom* trak)
 
         case AP4_CENC_VARIANT_MPEG_CBCS:
             cipher_mode = AP4_BlockCipher::CBC;
-            if (enc_format == AP4_ATOM_TYPE_ENCV) {
+            if (enc_format == AP4_ATOM_TYPE_ENCV || (enc_format == AP4_ATOM_TYPE_ENCA && format == AP4_ATOM_TYPE_AC_4)) {
                 crypt_byte_block = 1;
                 skip_byte_block  = 9;
             }
@@ -1632,24 +1669,38 @@ AP4_CencEncryptingProcessor::CreateTrackHandler(AP4_TrakAtom* trak)
     
     // compute the size of NAL units
     unsigned int nalu_length_size = 0;
-    if (format == AP4_ATOM_TYPE_AVC1 ||
-        format == AP4_ATOM_TYPE_AVC2 ||
-        format == AP4_ATOM_TYPE_AVC3 ||
-        format == AP4_ATOM_TYPE_AVC4 ||
-        format == AP4_ATOM_TYPE_DVAV ||
-        format == AP4_ATOM_TYPE_DVA1) {
-        AP4_AvccAtom* avcc = AP4_DYNAMIC_CAST(AP4_AvccAtom, entries[0]->GetChild(AP4_ATOM_TYPE_AVCC));
-        if (avcc) {
-            nalu_length_size = avcc->GetNaluLengthSize();
+    bool use_subsample_encryption = false;
+    switch (format) {
+        case AP4_ATOM_TYPE_AVC1:
+        case AP4_ATOM_TYPE_AVC2:
+        case AP4_ATOM_TYPE_AVC3:
+        case AP4_ATOM_TYPE_AVC4:
+        case AP4_ATOM_TYPE_DVAV:
+        case AP4_ATOM_TYPE_DVA1: {
+            AP4_AvccAtom* avcc = AP4_DYNAMIC_CAST(AP4_AvccAtom, entries[0]->GetChild(AP4_ATOM_TYPE_AVCC));
+            if (avcc) {
+                nalu_length_size = avcc->GetNaluLengthSize();
+                use_subsample_encryption = (nalu_length_size > 0);
+            }
+            break;
         }
-    } else if (format == AP4_ATOM_TYPE_HEV1 ||
-               format == AP4_ATOM_TYPE_HVC1 ||
-               format == AP4_ATOM_TYPE_DVHE ||
-               format == AP4_ATOM_TYPE_DVH1) {
-        AP4_HvccAtom* hvcc = AP4_DYNAMIC_CAST(AP4_HvccAtom, entries[0]->GetChild(AP4_ATOM_TYPE_HVCC));
-        if (hvcc) {
-            nalu_length_size = hvcc->GetNaluLengthSize();
+        case AP4_ATOM_TYPE_HEV1:
+        case AP4_ATOM_TYPE_HVC1:
+        case AP4_ATOM_TYPE_DVHE:
+        case AP4_ATOM_TYPE_DVH1: {
+            AP4_HvccAtom* hvcc = AP4_DYNAMIC_CAST(AP4_HvccAtom, entries[0]->GetChild(AP4_ATOM_TYPE_HVCC));
+            if (hvcc) {
+                nalu_length_size = hvcc->GetNaluLengthSize();
+                use_subsample_encryption = (nalu_length_size > 0);
+            }
+            break;
         }
+        case AP4_ATOM_TYPE_AC_4:
+            use_subsample_encryption = true;
+            break;
+        default:
+            use_subsample_encryption = false;
+            break;
     }
 
     // add a new cipher state for this track
@@ -1662,7 +1713,7 @@ AP4_CencEncryptingProcessor::CreateTrackHandler(AP4_TrakAtom* trak)
                 stream_cipher = new AP4_PatternStreamCipher(stream_cipher, crypt_byte_block, skip_byte_block);
             }
 
-            if (nalu_length_size) {
+            if (use_subsample_encryption) {
                 AP4_CencSubSampleMapper* subsample_mapper = NULL;
                 if (m_Variant == AP4_CENC_VARIANT_MPEG_CBCS) {
                     subsample_mapper = new AP4_CencCbcsSubSampleMapper(nalu_length_size, format, trak);
@@ -1684,7 +1735,7 @@ AP4_CencEncryptingProcessor::CreateTrackHandler(AP4_TrakAtom* trak)
             if (crypt_byte_block && skip_byte_block) {
                 stream_cipher = new AP4_PatternStreamCipher(stream_cipher, crypt_byte_block, skip_byte_block);
             }
-            if (nalu_length_size) {
+            if (use_subsample_encryption) {
                 AP4_CencSubSampleMapper* subsample_mapper = new AP4_CencAdvancedSubSampleMapper(nalu_length_size, format);
                 sample_encrypter = new AP4_CencCtrSubSampleEncrypter(stream_cipher,
                                                                      constant_iv,

--- a/Source/C++/Core/Ap4Utils.cpp
+++ b/Source/C++/Core/Ap4Utils.cpp
@@ -581,4 +581,13 @@ AP4_BitReader::SkipBit()
    }
 }
 
+/*----------------------------------------------------------------------
+|   AP4_BitReader::GetPosition
++---------------------------------------------------------------------*/
+unsigned int
+AP4_BitReader::GetBitsPosition()
+{
+    return m_Position * 8 - m_BitsCached;
+}
+
 

--- a/Source/C++/Core/Ap4Utils.h
+++ b/Source/C++/Core/Ap4Utils.h
@@ -263,6 +263,8 @@ public:
     void         SkipBit();
     void         SkipBits(unsigned int bit_count);
 
+    unsigned int GetBitsPosition();
+
     unsigned int GetBitsRead();
 
 private:


### PR DESCRIPTION
**Description**

This PR introduces support for subsample encryption for Dolby AC-4 audio streams including muxing and packaging in Bento4.

**Motivation**

Subsample encryption is a mode of Common Encryption (CENC) that allows selective encryption of media samples, leaving specific portions (such as headers) in the clear. In most cases, subsample encryption is applied to video streams (e.g., H.265/HEVC or AV1). It can also be used for audio streams, even though many pipelines default to full-sample encryption for audio. For Dolby AC-4, this is particularly useful because the AC-4 frame header (ac4_toc) contains configuration data that must remain accessible to parsers and playback systems even when the rest of the frame is encrypted.
By implementing subsample encryption for AC-4:
- Parsers can validate and process encrypted streams without full decryption.
- Playback systems can perform certain bitstream operations (e.g., stream identification, sync validation) efficiently.
- This aligns with best practices for encrypted media delivery and improves performance with streaming platforms.

**Implementation Details**

- The implementation ensures that the ac4_toc() portion of each AC-4 frame remains unencrypted.
- The remaining payload is encrypted using the selected CENC protection scheme (e.g., cbcs or cenc).

**Specification Reference**

This feature is not mentioned in any published specification. However, it is discussed in detail in the specification, which has not yet been publicly released but is expected to be published in the near future. Once available, it will provide formal guidance on subsample encryption for AC-4, including the handling of the ac4_toc() structure and encryption boundaries.

**Notes**

- This implementation is compatible with the upcoming public release of the AC-4 ISOBMFF specification.
- The feature has been tested on muxing/demuxing, encryption/decryption, DASH, HLS, and DRM. The generated content is conforms to expected encryption behavior. 
- Additional documentation will be provided once the specification is officially published.