### PR TITLE
fix #1045

### DIFF
--- a/Source/C++/Core/Ap4Atom.h
+++ b/Source/C++/Core/Ap4Atom.h
@@ -108,12 +108,12 @@ public:
     virtual void StartObject(const char* /* name */, unsigned int field_count = 0, bool compact = false) {}
     virtual void EndObject() {}
     virtual void AddField(const char* /* name */,
-                          AP4_UI64    /* value */, 
+                          AP4_UI64    /* value */,
                           FormatHint  hint = HINT_NONE) {
         (void)hint; // gcc warning
     }
-    virtual void AddFieldF(const char* /* name */, 
-                           float       /* value */, 
+    virtual void AddFieldF(const char* /* name */,
+                           float       /* value */,
                            FormatHint  hint = HINT_NONE) {
         (void)hint; // gcc warning
     }

--- a/Source/C++/Core/Ap4TrunAtom.cpp
+++ b/Source/C++/Core/Ap4TrunAtom.cpp
@@ -314,7 +314,9 @@ AP4_TrunAtom::InspectFields(AP4_AtomInspector& inspector)
             }
             if (m_Flags & AP4_TRUN_FLAG_SAMPLE_COMPOSITION_TIME_OFFSET_PRESENT) {
                 inspector.AddField(inspector.GetVerbosity() >= 2 ? "sample_composition_time_offset" : "c",
-                                   m_Entries[i].sample_composition_time_offset);
+                                   m_Version == 0 ?
+                                   m_Entries[i].sample_composition_time_offset :
+                                   static_cast<AP4_UI64>(static_cast<AP4_SI32>(m_Entries[i].sample_composition_time_offset)));
             }
 
             inspector.EndObject();


### PR DESCRIPTION
When `trun` box version is 1, the sample composition time offset is signed.