### PR TITLE
Fix heap buffer overflow in AP4_Ac4Parser and AP4_Dac4Atom

### DIFF
--- a/Source/C++/Codecs/Ap4Ac4Parser.cpp
+++ b/Source/C++/Codecs/Ap4Ac4Parser.cpp
@@ -131,6 +131,11 @@ AP4_Ac4Header::AP4_Ac4Header(const AP4_UI08* bytes, unsigned int size, bool head
         }
         // ac4_presentation_v1_info()
         for (unsigned int pres_idx = 0; pres_idx < m_NPresentations; pres_idx++){
+            if (!bits.GetBitsAvailable()) {
+                printf("Error: Not enough bits for %d PresentationV1Info, stop parsing.\n", m_NPresentations);
+                return;
+            }
+
             AP4_Dac4Atom::Ac4Dsi::PresentationV1& presentation = m_PresentationV1[pres_idx];
             presentation.ParsePresentationV1Info(bits,
                                                  m_BitstreamVersion,
@@ -146,6 +151,11 @@ AP4_Ac4Header::AP4_Ac4Header(const AP4_UI08* bytes, unsigned int size, bool head
         AP4_Dac4Atom::Ac4Dsi::SubStreamGroupV1 *substream_groups = new AP4_Dac4Atom::Ac4Dsi::SubStreamGroupV1[maxGroupIndex + 1];
         AP4_SetMemory(substream_groups, 0, (maxGroupIndex + 1) * sizeof(substream_groups[0]));
         for (unsigned int sg = 0 ; (sg < (maxGroupIndex + 1)) && (m_NPresentations > 0); sg ++) {
+            if (!bits.GetBitsAvailable()) {
+                printf("Error: Not enough bits for %d SubstreamGroupInfo, stop parsing.\n", maxGroupIndex + 1);
+                return;
+            }
+
             AP4_Dac4Atom::Ac4Dsi::SubStreamGroupV1 &substream_group = substream_groups[sg];
             AP4_Result pres_index = GetPresentationIndexBySGIndex(sg);
             if (pres_index == AP4_FAILURE) {

--- a/Source/C++/Core/Ap4Dac4Atom.cpp
+++ b/Source/C++/Core/Ap4Dac4Atom.cpp
@@ -196,6 +196,10 @@ AP4_Dac4Atom::AP4_Dac4Atom(AP4_UI32 size, const AP4_UI08* payload) :
         m_Dsi.d.v1.presentations = new Ac4Dsi::PresentationV1[m_Dsi.d.v1.n_presentations];
         AP4_SetMemory(m_Dsi.d.v1.presentations, 0, m_Dsi.d.v1.n_presentations * sizeof(m_Dsi.d.v1.presentations[0]));
         for (unsigned int i = 0; i < m_Dsi.d.v1.n_presentations; i++) {
+            if (!bits.GetBitsAvailable()) {
+                printf("Error: Not enough bits for %d presentation, stop parsing.\n", m_Dsi.d.v1.n_presentations);
+                return;
+            }
             Ac4Dsi::PresentationV1& presentation = m_Dsi.d.v1.presentations[i];
             
             presentation.presentation_version = bits.ReadBits(8);

--- a/Source/C++/Core/Ap4Utils.cpp
+++ b/Source/C++/Core/Ap4Utils.cpp
@@ -438,6 +438,22 @@ AP4_BitReader::GetBitsRead()
 }
 
 /*----------------------------------------------------------------------
+|   AP4_BitReader::GetBitsAvailable
++---------------------------------------------------------------------*/
+unsigned int
+AP4_BitReader::GetBitsAvailable()
+{
+    unsigned int bits_read = GetBitsRead();
+    unsigned int bits_total = 8*m_Buffer.GetDataSize();
+
+    if (bits_read >= bits_total) {
+        return 0;
+    }
+
+    return bits_total - bits_read;
+}
+
+/*----------------------------------------------------------------------
 |   AP4_BitReader::ReadCache
 +---------------------------------------------------------------------*/
 AP4_BitReader::BitsWord

--- a/Source/C++/Core/Ap4Utils.h
+++ b/Source/C++/Core/Ap4Utils.h
@@ -266,6 +266,7 @@ public:
     unsigned int GetBitsPosition();
 
     unsigned int GetBitsRead();
+    unsigned int GetBitsAvailable();
 
 private:
     // methods


### PR DESCRIPTION
Changes:

- Added GetBitsAvailable() method to AP4_BitReader to expose the number of bits remaining in the buffer
- Added bounds checking with appropriate error handling to prevent out-of-bounds reads when parsing malformed/maliciously crafted MP4 files

Related Issues: https://github.com/axiomatic-systems/Bento4/issues/1060, https://github.com/axiomatic-systems/Bento4/issues/1059, https://github.com/axiomatic-systems/Bento4/issues/1058