### PR TITLE
Fix video/audio only encryption packaging issue

### DIFF
--- a/Source/Python/utils/mp4-dash.py
+++ b/Source/Python/utils/mp4-dash.py
@@ -775,7 +775,7 @@ def OutputHlsCommon(options, track, all_tracks, media_subdir, playlist_name, med
         init_segment_size = track.parent.init_segment.position + track.parent.init_segment.size
         playlist_file.write('#EXT-X-MAP:URI="{}",BYTERANGE="{}@0"\n'.format(media_file_name, init_segment_size))
 
-    if options.encryption_key:
+    if options.encryption_key and track.key_info:
         key_lines = []
         if options.fairplay_key_uri:
             key_lines.append(ComputeHlsFairplayKeyLine(options))


### PR DESCRIPTION
### Summary
This PR fixes an HLS packaging issue in mp4-dash.py when only selected tracks are encrypted using filtered --encryption-key values such as audio:KID:KEY:IV or video:KID:KEY:IV.

Previously, when options.encryption_key was set globally, OutputHlsCommon() always attempted to write an #EXT-X-KEY line for every HLS media playlist. However, when only the audio track was encrypted, the video track did not have track.key_info['iv'], which caused packaging to fail with:

```
SZO-YFAN-MBP14:Bento4 yfan$ python3 Source/Python/utils/mp4-dash.py --hls -o output/ -f /Users/yfan/Documents/dv_encoding_tools/packaging/outputs_f/video_dvh1_0_f.mp4 /Users/yfan/Documents/dv_encoding_tools/packaging/outputs_f/audio_artist_f.mp4 --encryption-key audio:79ade23c7fc5b7473716ff2cdeed1dc4:3f960506da95451c92c149f2bf437edb:3f960506da95451c92c149f2bf437edb --encryption-cenc-scheme cbcs
Encrypting track IDs [1] in /Users/yfan/Documents/dv_encoding_tools/packaging/outputs_f/audio_artist_f.mp4
Parsing media file 1: /Users/yfan/Documents/dv_encoding_tools/packaging/outputs_f/video_dvh1_0_f.mp4
Parsing media file 2: tmpbzvi1bug = Encrypted[/Users/yfan/Documents/dv_encoding_tools/packaging/outputs_f/audio_artist_f.mp4]
Splitting media file (audio) tmpbzvi1bug = Encrypted[/Users/yfan/Documents/dv_encoding_tools/packaging/outputs_f/audio_artist_f.mp4]
Splitting media file (video) /Users/yfan/Documents/dv_encoding_tools/packaging/outputs_f/video_dvh1_0_f.mp4
ERROR: 'iv'
```

### Change

The HLS key signaling condition was updated from:
`if options.encryption_key:`
to:
`if options.encryption_key and track.key_info:`
This ensures that #EXT-X-KEY is only written for tracks that actually have encryption key information.

### Test

Reproduced the issue with audio-only encryption:

```
SZO-YFAN-MBP14:Bento4 yfan$ python3 Source/Python/utils/mp4-dash.py --hls -o output/ -f /Users/yfan/Documents/dv_encoding_tools/packaging/outputs_f/video_dvh1_0_f.mp4 /Users/yfan/Documents/dv_encoding_tools/packaging/outputs_f/audio_artist_f.mp4 --encryption-key audio:79ade23c7fc5b7473716ff2cdeed1dc4:3f960506da95451c92c149f2bf437edb:3f960506da95451c92c149f2bf437edb --encryption-cenc-scheme cbcs
Encrypting track IDs [1] in /Users/yfan/Documents/dv_encoding_tools/packaging/outputs_f/audio_artist_f.mp4
Parsing media file 1: /Users/yfan/Documents/dv_encoding_tools/packaging/outputs_f/video_dvh1_0_f.mp4
Parsing media file 2: tmp6mq51al9 = Encrypted[/Users/yfan/Documents/dv_encoding_tools/packaging/outputs_f/audio_artist_f.mp4]
Splitting media file (audio) tmp6mq51al9 = Encrypted[/Users/yfan/Documents/dv_encoding_tools/packaging/outputs_f/audio_artist_f.mp4]
Splitting media file (video) /Users/yfan/Documents/dv_encoding_tools/packaging/outputs_f/video_dvh1_0_f.mp4
SZO-YFAN-MBP14:Bento4 yfan$ 
```