### PR TITLE
Fix SampleBuffer leak in AP4_LinearReader::Tracker destructor

### DIFF
--- a/Source/C++/Core/Ap4LinearReader.cpp
+++ b/Source/C++/Core/Ap4LinearReader.cpp
@@ -621,6 +621,8 @@ AP4_LinearReader::FindTracker(AP4_UI32 track_id)
 AP4_LinearReader::Tracker::~Tracker()
 {
     if (m_SampleTableIsOwned) delete m_SampleTable;
+    m_Samples.DeleteReferences();
+    delete m_NextSample;
     delete m_Reader;
 }
 


### PR DESCRIPTION
Make ~Tracker() call m_Samples.DeleteReferences() and delete m_NextSample. SampleBuffer objects buffered in the sample queue but never popped were leaked when the reader was destroyed. Reproducible with included audio+video fmp4 streams.

Sanitizer report before the fix:
```
=================================================================
==11461==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 3120 byte(s) in 78 object(s) allocated from:
    #0 0x7ff966f2d341 in operator new(unsigned long) (/usr/lib/libasan.so.8+0x12d341) (BuildId: ee5fbab73143ab257a66a33afe0f038a4af7a74e)
    #1 0x562a71748918 in AP4_LinearReader::Advance(bool) /home/dobo/kodi/Bento4/Source/C++/Core/Ap4LinearReader.cpp:453
    #2 0x562a717491e8 in AP4_LinearReader::ReadNextSample(unsigned int, AP4_Sample&, AP4_DataBuffer&) /home/dobo/kodi/Bento4/Source/C++/Core/Ap4LinearReader.cpp:531
    #3 0x562a717409af in main Source/C++/Test/StreamLeak/StreamLeakTest.cpp:41
    #4 0x7ff966027740  (/usr/lib/libc.so.6+0x27740) (BuildId: 020d6f7c33b2413f4fe10814c4729dce1387f049)
    #5 0x7ff966027878 in __libc_start_main (/usr/lib/libc.so.6+0x27878) (BuildId: 020d6f7c33b2413f4fe10814c4729dce1387f049)
    #6 0x562a71740444 in _start (/home/dobo/kodi/Bento4/build_test/streamleaktest+0x325444) (BuildId: a06990f3365b1e9684678fb3ed878d9662add79e)

Indirect leak of 7044 byte(s) in 78 object(s) allocated from:
    #0 0x7ff966f2d4d1 in operator new[](unsigned long) (/usr/lib/libasan.so.8+0x12d4d1) (BuildId: ee5fbab73143ab257a66a33afe0f038a4af7a74e)
    #1 0x562a71741a84 in AP4_DataBuffer::ReallocateBuffer(unsigned int) /home/dobo/kodi/Bento4/Source/C++/Core/Ap4DataBuffer.cpp:210
    #2 0x562a7174178f in AP4_DataBuffer::SetDataSize(unsigned int) /home/dobo/kodi/Bento4/Source/C++/Core/Ap4DataBuffer.cpp:151
    #3 0x562a7175187d in AP4_Sample::ReadData(AP4_DataBuffer&, unsigned int, unsigned int) /home/dobo/kodi/Bento4/Source/C++/Core/Ap4Sample.cpp:156
    #4 0x562a7175160a in AP4_Sample::ReadData(AP4_DataBuffer&) /home/dobo/kodi/Bento4/Source/C++/Core/Ap4Sample.cpp:127
    #5 0x562a71748a89 in AP4_LinearReader::Advance(bool) /home/dobo/kodi/Bento4/Source/C++/Core/Ap4LinearReader.cpp:459
    #6 0x562a717491e8 in AP4_LinearReader::ReadNextSample(unsigned int, AP4_Sample&, AP4_DataBuffer&) /home/dobo/kodi/Bento4/Source/C++/Core/Ap4LinearReader.cpp:531
    #7 0x562a717409af in main Source/C++/Test/StreamLeak/StreamLeakTest.cpp:41
    #8 0x7ff966027740  (/usr/lib/libc.so.6+0x27740) (BuildId: 020d6f7c33b2413f4fe10814c4729dce1387f049)
    #9 0x7ff966027878 in __libc_start_main (/usr/lib/libc.so.6+0x27878) (BuildId: 020d6f7c33b2413f4fe10814c4729dce1387f049)
    #10 0x562a71740444 in _start (/home/dobo/kodi/Bento4/build_test/streamleaktest+0x325444) (BuildId: a06990f3365b1e9684678fb3ed878d9662add79e)

Indirect leak of 3744 byte(s) in 78 object(s) allocated from:
    #0 0x7ff966f2d341 in operator new(unsigned long) (/usr/lib/libasan.so.8+0x12d341) (BuildId: ee5fbab73143ab257a66a33afe0f038a4af7a74e)
    #1 0x562a717484ed in AP4_LinearReader::Advance(bool) /home/dobo/kodi/Bento4/Source/C++/Core/Ap4LinearReader.cpp:422
    #2 0x562a717491e8 in AP4_LinearReader::ReadNextSample(unsigned int, AP4_Sample&, AP4_DataBuffer&) /home/dobo/kodi/Bento4/Source/C++/Core/Ap4LinearReader.cpp:531
    #3 0x562a717409af in main Source/C++/Test/StreamLeak/StreamLeakTest.cpp:41
    #4 0x7ff966027740  (/usr/lib/libc.so.6+0x27740) (BuildId: 020d6f7c33b2413f4fe10814c4729dce1387f049)
    #5 0x7ff966027878 in __libc_start_main (/usr/lib/libc.so.6+0x27878) (BuildId: 020d6f7c33b2413f4fe10814c4729dce1387f049)
    #6 0x562a71740444 in _start (/home/dobo/kodi/Bento4/build_test/streamleaktest+0x325444) (BuildId: a06990f3365b1e9684678fb3ed878d9662add79e)

SUMMARY: AddressSanitizer: 13908 byte(s) leaked in 234 allocation(s).
```

Code reproducing the issue:
```cpp
#include <stdio.h>
#include <stdlib.h>

#include <Ap4.h>

#define CHECK(x) do { \
    if (!(x)) { \
        fprintf(stderr,"ERR %d\n", __LINE__); \
        return 1; \
    } \
} while (0)

int main() {
    const char* fn = "Test/Data/video-h264-002.mp4";

    AP4_ByteStream* inp = NULL;
    CHECK(AP4_SUCCEEDED(AP4_FileByteStream::Create(fn, AP4_FileByteStream::STREAM_MODE_READ, inp)));
    AP4_File* f = new AP4_File(*inp, true);
    AP4_Movie* mov = f->GetMovie();
    CHECK(mov);

    AP4_Track* video = mov->GetTrack(AP4_Track::TYPE_VIDEO);
    AP4_Track* audio = mov->GetTrack(AP4_Track::TYPE_AUDIO);
    CHECK(video);
    CHECK(audio);

    fprintf(stderr, "Video: %d samples, Audio: %d samples\n",
            static_cast<int>(video->GetSampleCount()), static_cast<int>(audio->GetSampleCount()));

    AP4_LinearReader rdr(*mov, inp);

    rdr.EnableTrack(video->GetId());
    rdr.EnableTrack(audio->GetId());

    AP4_Sample s;
    AP4_DataBuffer d;
    int n = 0;

    for (;;) {
        // Only read video: audio samples pile up in audio tracker's m_Samples
        AP4_Result r = rdr.ReadNextSample(video->GetId(), s, d);
        if (AP4_FAILED(r)) {
            fprintf(stderr, "Err %d / %d video samples read\n", r, n);
            break;
        }
        n++;
    }
    CHECK(n > 0);

    // At this point the audio tracker's m_Samples is full of unpopped samples

    inp->Release();
    delete f;
    return 0;
}
```