### PR TITLE
Fix HLS VIDEO-RANGE generation for non-Dolby Vision HDR content

### DIFF
--- a/Source/C++/Apps/Mp4Info/Mp4Info.cpp
+++ b/Source/C++/Apps/Mp4Info/Mp4Info.cpp
@@ -1081,6 +1081,22 @@ ShowSampleDescription_Json(AP4_SampleDescription& description, bool verbose)
         printf("}");
     }
 
+    // Color information from colr atom for non-VPx tracks
+    if (desc->GetFormat() != AP4_SAMPLE_FORMAT_VP8 &&
+        desc->GetFormat() != AP4_SAMPLE_FORMAT_VP9 &&
+        desc->GetFormat() != AP4_SAMPLE_FORMAT_VP10) {
+        AP4_ColrAtom* colr = AP4_DYNAMIC_CAST(AP4_ColrAtom, desc->GetDetails().GetChild(AP4_ATOM_TYPE_COLR));
+        if (colr && colr->GetColourParameterType() == AP4_SAMPLE_COLOR_TYPE_NCLX) {
+            printf(",\n");
+            printf("\"color_info\": {\n");
+            printf("    \"colour_primaries\":%d,\n", colr->GetPrimariesIndex());
+            printf("    \"transfer_characteristics\":%d,\n", colr->GetTransferFunctionIndex());
+            printf("    \"matrix_coefficients\":%d,\n", colr->GetMatrixIndex());
+            printf("    \"video_full_range_flag\":%s\n", colr->GetFullRangeFlag() ? "true" : "false");
+            printf("}");
+        }
+    }
+
     printf("\n}");
 }
 

--- a/Source/C++/Core/Ap4.h
+++ b/Source/C++/Core/Ap4.h
@@ -316,6 +316,7 @@
 #include "Ap4Dec3Atom.h"
 #include "Ap4Dac4Atom.h"
 #include "Ap4SidxAtom.h"
+#include "Ap4ColrAtom.h"
 #include "Ap4AdtsParser.h"
 #include "Ap4Ac4Parser.h"
 #include "Ap4AvcParser.h"

--- a/Source/C++/Core/Ap4Atom.h
+++ b/Source/C++/Core/Ap4Atom.h
@@ -588,6 +588,7 @@ const AP4_Atom::Type AP4_ATOM_TYPE_SIDX = AP4_ATOM_TYPE('s','i','d','x');
 const AP4_Atom::Type AP4_ATOM_TYPE_SSIX = AP4_ATOM_TYPE('s','s','i','x');
 const AP4_Atom::Type AP4_ATOM_TYPE_SBGP = AP4_ATOM_TYPE('s','b','g','p');
 const AP4_Atom::Type AP4_ATOM_TYPE_SGPD = AP4_ATOM_TYPE('s','g','p','d');
+const AP4_Atom::Type AP4_ATOM_TYPE_COLR = AP4_ATOM_TYPE('c','o','l','r');
 
 /*----------------------------------------------------------------------
 |   AP4_AtomListInspector

--- a/Source/C++/Core/Ap4AtomFactory.cpp
+++ b/Source/C++/Core/Ap4AtomFactory.cpp
@@ -108,6 +108,7 @@
 #include "Ap4SidxAtom.h"
 #include "Ap4SbgpAtom.h"
 #include "Ap4SgpdAtom.h"
+#include "Ap4ColrAtom.h"
 
 /*----------------------------------------------------------------------
 |   AP4_AtomFactory::~AP4_AtomFactory
@@ -835,6 +836,10 @@ AP4_AtomFactory::CreateAtomFromStream(AP4_ByteStream& stream,
           case AP4_ATOM_TYPE_MDAT:
             // generic atoms
             break;
+          case AP4_ATOM_TYPE_COLR:
+              if (atom_is_large) return AP4_ERROR_INVALID_FORMAT;
+              atom = AP4_ColrAtom::Create(size_32, stream);
+              break;
             
           default: {
             // try all the external type handlers

--- a/Source/C++/Core/Ap4ColrAtom.cpp
+++ b/Source/C++/Core/Ap4ColrAtom.cpp
@@ -1,0 +1,165 @@
+/*****************************************************************
+|
+|    AP4 - hvcC Atoms
+|
+|    Copyright 2002-2016 Axiomatic Systems, LLC
+|
+|
+|    This file is part of Bento4/AP4 (MP4 Atom Processing Library).
+|
+|    Unless you have obtained Bento4 under a difference license,
+|    this version of Bento4 is Bento4|GPL.
+|    Bento4|GPL is free software; you can redistribute it and/or modify
+|    it under the terms of the GNU General Public License as published by
+|    the Free Software Foundation; either version 2, or (at your option)
+|    any later version.
+|
+|    Bento4|GPL is distributed in the hope that it will be useful,
+|    but WITHOUT ANY WARRANTY; without even the implied warranty of
+|    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+|    GNU General Public License for more details.
+|
+|    You should have received a copy of the GNU General Public License
+|    along with Bento4|GPL; see the file COPYING.  If not, write to the
+|    Free Software Foundation, 59 Temple Place - Suite 330, Boston, MA
+|    02111-1307, USA.
+|
+****************************************************************/
+
+/*----------------------------------------------------------------------
+|   includes
++---------------------------------------------------------------------*/
+#include "Ap4ColrAtom.h"
+#include "Ap4AtomFactory.h"
+#include "Ap4Utils.h"
+#include "Ap4Types.h"
+#include "Ap4HevcParser.h"
+
+/*----------------------------------------------------------------------
+|   dynamic cast support
++---------------------------------------------------------------------*/
+AP4_DEFINE_DYNAMIC_CAST_ANCHOR(AP4_ColrAtom)
+
+
+/*----------------------------------------------------------------------
+|   AP4_ColrAtom::Create
++---------------------------------------------------------------------*/
+AP4_ColrAtom*
+AP4_ColrAtom::Create(AP4_Size size, AP4_ByteStream& stream)
+{
+    // read the raw bytes in a buffer
+    unsigned int payload_size = size-AP4_ATOM_HEADER_SIZE;
+    AP4_DataBuffer payload_data(payload_size);
+    AP4_Result result = stream.Read(payload_data.UseData(), payload_size);
+    if (AP4_FAILED(result)) return NULL;
+
+    return new AP4_ColrAtom(size, payload_data.GetData());
+}
+
+/*----------------------------------------------------------------------
+|   AP4_ColrAtom::AP4_ColrAtom
++---------------------------------------------------------------------*/
+AP4_ColrAtom::AP4_ColrAtom() :
+    AP4_Atom(AP4_ATOM_TYPE_COLR, AP4_ATOM_HEADER_SIZE + 11),
+    m_ColourParameterType(0),
+    m_PrimariesIndex(0),
+    m_TransferFunctionIndex(0),
+    m_MatrixIndex(0),
+    m_FullRangeFlag(0),
+    m_PayloadSize(11)
+{
+}
+
+/*----------------------------------------------------------------------
+|   AP4_ColrAtom::AP4_ColrAtom
++---------------------------------------------------------------------*/
+AP4_ColrAtom::AP4_ColrAtom(AP4_UI32 colour_parameter_type,
+                           AP4_UI16 primaries_index,
+                           AP4_UI16 transfer_function_index,
+                           AP4_UI16 matrix_index,
+                           AP4_UI08 video_full_range_flag,
+                           AP4_UI32 payload_size) :
+    AP4_Atom(AP4_ATOM_TYPE_COLR, AP4_ATOM_HEADER_SIZE + payload_size),
+    m_ColourParameterType(colour_parameter_type),
+    m_PrimariesIndex(primaries_index),
+    m_TransferFunctionIndex(transfer_function_index),
+    m_MatrixIndex(matrix_index),
+    m_FullRangeFlag(video_full_range_flag),
+    m_PayloadSize(payload_size)
+{
+}
+
+/*----------------------------------------------------------------------
+|   AP4_ColrAtom::AP4_ColrAtom
++---------------------------------------------------------------------*/
+AP4_ColrAtom::AP4_ColrAtom(AP4_UI32 size, const AP4_UI08* payload) :
+    AP4_Atom(AP4_ATOM_TYPE_COLR, size)
+{
+    // make a copy of our configuration bytes
+    unsigned int payload_size = size-AP4_ATOM_HEADER_SIZE;
+    // payload size of QuickTime colr is 10,
+    // payload size of ISOBMFF colr is 11.
+    if (payload_size != 10 && payload_size != 11) return;
+
+    // parse the payload
+    m_PayloadSize = payload_size;
+    m_ColourParameterType = AP4_BytesToUInt32BE(&payload[0]);
+    m_PrimariesIndex = AP4_BytesToUInt16BE(&payload[4]);
+    m_TransferFunctionIndex = AP4_BytesToUInt16BE(&payload[6]);
+    m_MatrixIndex = AP4_BytesToUInt16BE(&payload[8]);
+    if (payload_size == 11) {
+        m_FullRangeFlag = (payload[10] >> 7) & 0x01;
+    }
+
+}
+
+///*----------------------------------------------------------------------
+//|   AP4_ColrAtom::UpdateRawBytes
+//+---------------------------------------------------------------------*/
+//void
+//AP4_ColrAtom::UpdateRawBytes()
+//{
+//}
+
+/*----------------------------------------------------------------------
+|   AP4_ColrAtom::WriteFields
++---------------------------------------------------------------------*/
+AP4_Result
+AP4_ColrAtom::WriteFields(AP4_ByteStream& stream)
+{
+    AP4_UI08 payload[11];
+    AP4_SetMemory(&payload, 0, 11);
+
+    payload[0] = m_ColourParameterType >> 24;
+    payload[1] = (m_ColourParameterType >> 16) & 0xFF;
+    payload[2] = (m_ColourParameterType >> 8) & 0xFF;
+    payload[3] = m_ColourParameterType & 0xFF;
+    payload[4] = m_PrimariesIndex >> 8;
+    payload[5] = m_PrimariesIndex & 0xFF;
+    payload[6] = m_TransferFunctionIndex >> 8;
+    payload[7] = m_TransferFunctionIndex & 0xFF;
+    payload[8] = m_MatrixIndex >> 8;
+    payload[9] = m_MatrixIndex & 0xFF;
+    payload[10] = (m_FullRangeFlag << 7) & 0x80;
+
+    if (GetPayloadSize() == 10) {
+        return stream.Write(payload, 10);
+    }
+    return stream.Write(payload, 11);
+}
+
+/*----------------------------------------------------------------------
+|   AP4_ColrAtom::InspectFields
++---------------------------------------------------------------------*/
+AP4_Result
+AP4_ColrAtom::InspectFields(AP4_AtomInspector& inspector)
+{
+    inspector.AddField("Colour Parameter Type:", m_ColourParameterType);
+    inspector.AddField("Primaries Index:", m_PrimariesIndex);
+    inspector.AddField("Transfer Funcion Index:", m_TransferFunctionIndex);
+    inspector.AddField("Matrix Index:", m_MatrixIndex);
+    if (GetPayloadSize() == 11) {
+        inspector.AddField("Video Full Range Flag:", m_FullRangeFlag);
+    }
+    return AP4_SUCCESS;
+}

--- a/Source/C++/Core/Ap4ColrAtom.h
+++ b/Source/C++/Core/Ap4ColrAtom.h
@@ -1,0 +1,83 @@
+/*****************************************************************
+|
+|    AP4 - Colr Atoms
+|
+|    Copyright 2002-2014 Axiomatic Systems, LLC
+|
+|
+|    This file is part of Bento4/AP4 (MP4 Atom Processing Library).
+|
+|    Unless you have obtained Bento4 under a difference license,
+|    this version of Bento4 is Bento4|GPL.
+|    Bento4|GPL is free software; you can redistribute it and/or modify
+|    it under the terms of the GNU General Public License as published by
+|    the Free Software Foundation; either version 2, or (at your option)
+|    any later version.
+|
+|    Bento4|GPL is distributed in the hope that it will be useful,
+|    but WITHOUT ANY WARRANTY; without even the implied warranty of
+|    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+|    GNU General Public License for more details.
+|
+|    You should have received a copy of the GNU General Public License
+|    along with Bento4|GPL; see the file COPYING.  If not, write to the
+|    Free Software Foundation, 59 Temple Place - Suite 330, Boston, MA
+|    02111-1307, USA.
+|
+****************************************************************/
+
+#ifndef _AP4_COLR_ATOM_H_
+#define _AP4_COLR_ATOM_H_
+
+/*----------------------------------------------------------------------
+|   includes
++---------------------------------------------------------------------*/
+#include "Ap4Atom.h"
+#include "Ap4Array.h"
+
+/*----------------------------------------------------------------------
+|   AP4_ColrAtom
++---------------------------------------------------------------------*/
+class AP4_ColrAtom : public AP4_Atom
+{
+public:
+    AP4_IMPLEMENT_DYNAMIC_CAST_D(AP4_ColrAtom, AP4_Atom)
+
+    // class methods
+    static AP4_ColrAtom* Create(AP4_Size size, AP4_ByteStream& stream);
+
+    // constructors
+    AP4_ColrAtom();
+    AP4_ColrAtom(AP4_UI32 colour_parameter_type,
+                 AP4_UI16 primaries_index,
+                 AP4_UI16 transfer_function_index,
+                 AP4_UI16 matrix_index,
+                 AP4_UI08 video_full_range_flag,
+                 AP4_UI32 payload_size = 11); // default payload size is 11, unless specified
+    AP4_ColrAtom(AP4_UI32 size, const AP4_UI08* payload);
+
+    // methods
+    virtual AP4_Result InspectFields(AP4_AtomInspector& inspector);
+    virtual AP4_Result WriteFields(AP4_ByteStream& stream);
+
+    // accessors
+    AP4_UI32 GetColourParameterType()            { return m_ColourParameterType; }
+    AP4_UI16 GetPrimariesIndex()                 { return m_PrimariesIndex; }
+    AP4_UI16 GetTransferFunctionIndex()          { return m_TransferFunctionIndex; }
+    AP4_UI16 GetMatrixIndex()                    { return m_MatrixIndex; }
+    AP4_UI08 GetFullRangeFlag()                  { return m_FullRangeFlag; }
+    AP4_UI32 GetPayloadSize()                    { return m_PayloadSize; }
+
+private:
+
+    // members
+    AP4_UI32                  m_ColourParameterType;
+    AP4_UI16                  m_PrimariesIndex;
+    AP4_UI16                  m_TransferFunctionIndex;
+    AP4_UI16                  m_MatrixIndex;
+    AP4_UI08                  m_FullRangeFlag;
+    AP4_UI32                  m_PayloadSize;
+
+};
+
+#endif // _AP4_COLR_ATOM_H_

--- a/Source/C++/Core/Ap4SampleDescription.h
+++ b/Source/C++/Core/Ap4SampleDescription.h
@@ -106,6 +106,7 @@ const AP4_UI32 AP4_SAMPLE_FORMAT_OPUS = AP4_ATOM_TYPE('O','p','u','s');
 const AP4_UI32 AP4_SAMPLE_FORMAT_VP8  = AP4_ATOM_TYPE('v','p','0','8');
 const AP4_UI32 AP4_SAMPLE_FORMAT_VP9  = AP4_ATOM_TYPE('v','p','0','9');
 const AP4_UI32 AP4_SAMPLE_FORMAT_VP10 = AP4_ATOM_TYPE('v','p','1','0');
+const AP4_UI32 AP4_SAMPLE_COLOR_TYPE_NCLX = AP4_ATOM_TYPE('n','c','l','x');
 
 const char*
 AP4_GetFormatName(AP4_UI32 format);

--- a/Source/Python/utils/mp4utils.py
+++ b/Source/Python/utils/mp4utils.py
@@ -413,7 +413,7 @@ class Mp4Track:
             self.width  = sample_desc['width']
             self.height = sample_desc['height']
 
-            # add dolby vision signaling if present
+            # add dolby vision signaling if present; otherwise detect HDR10/HLG
             if 'dolby_vision' in sample_desc:
                 dv_info = sample_desc['dolby_vision']
                 if dv_info['profile'] == 5:
@@ -459,6 +459,18 @@ class Mp4Track:
                         PrintErrorAndExit('ERROR: unsupported ccid for Dolby Vision profile 8/9.')
                 else:
                     PrintErrorAndExit('ERROR: unsupported Dolby Vision profile.')
+            elif 'color_info' in sample_desc:
+                tc = sample_desc['color_info'].get('transfer_characteristics', 1)
+                if tc == 16: 
+                    self.video_range = 'PQ'
+                elif tc == 18: 
+                    self.video_range = 'HLG'
+            elif 'vpx_info' in sample_desc:
+                tc = sample_desc['vpx_info'].get('transfer_characteristics', 1)
+                if tc == 16: 
+                    self.video_range = 'PQ'
+                elif tc == 18:
+                    self.video_range = 'HLG'
 
         if self.type == 'audio':
             self.sample_rate = sample_desc['sample_rate']


### PR DESCRIPTION
### Background

When packaging HDR AV1 content into HLS using mp4-dash.py, Apple Media Stream Validator reports the following error:

```
Error: Detected segment video transfer function does not match playlist declared video range
--> Detail:  Playlist attribute SDR, Video transfer function SMPTE_ST_2084_PQ
--> Source:  output_hls/master.m3u8
--> Compare: video-av01-1.m3u8
```

This indicates that the generated HLS playlists declare the stream as SDR, while the actual video segments use the PQ transfer function (SMPTE_ST_2084_PQ) and should be signaled as HDR.

### Reproduction

Media files:

https://github.com/user-attachments/assets/41425ab5-ef98-4fc2-940b-7507f02415b2

https://github.com/user-attachments/assets/1f2f73e1-d4d0-42f1-9f92-dc3c88227d0c

Test script:

```bash
#!/bin/bash

BENTO4_DIR="$PWD"
MP4_FRAG="$BENTO4_DIR/cmakebuild/mp4fragment"
MP4_DASH="$BENTO4_DIR/Source/Python/utils/mp4-dash.py"

INPUT_MP4_1="$BENTO4_DIR/ChromaPulse__HDR10__1280x720_30fps__BT2100_PQ__AV1.mp4"
INPUT_MP4_2="$BENTO4_DIR/ChromaPulse__HDR10__1920x1080_30fps__BT2100_PQ__AV1.mp4"

# Fragment
$MP4_FRAG $INPUT_MP4_1 frag_720p.mp4
$MP4_FRAG $INPUT_MP4_2 frag_1080p.mp4

# Package
$MP4_DASH --hls -f --profile "on-demand" --no-split \
    -o output_hls/ \
    frag_720p.mp4 frag_1080p.mp4

# Validate
mediastreamvalidator \
    -O output_hls/validator.json \
    output_hls/master.m3u8
```

### Root Cause

mp4-dash.py **only generated the HLS VIDEO-RANGE attribute for Dolby Vision content.**

For non-Dolby Vision HDR streams (for example HDR10 with PQ transfer characteristics), the script did not derive or emit the correct VIDEO-RANGE value, causing HLS playlists to default to SDR signaling.

As a result, the playlist metadata became inconsistent with the actual video characteristics contained in the media segments.

### Changes

1. Extend HLS VIDEO-RANGE generation logic beyond Dolby Vision streams.

2. Detect HDR video characteristics from track metadata.

3. Generate the appropriate VIDEO-RANGE value for non-Dolby Vision HDR content.

### Validation

After applying this change, the VIDEO-RANGE validation errors are no longer reported by Apple Media Stream Validator.

Validator output after this fix:

```
--------------------------------------------------------------------------------
MUST fix issues
--------------------------------------------------------------------------------

Error: Measured peak bitrate compared to multivariant playlist declared value exceeds error tolerance
--> Detail:  Measured: 1027.50 kb/s, Multivariant playlist: 724.21 kb/s, Error: 41.88%
--> Source:  output_hls/master.m3u8
--> Compare: video-av01-1.m3u8

--------------------------------------------------------------------------------

```

The original VIDEO-RANGE mismatch issue has been resolved. The remaining bitrate validation warning is unrelated to this change and should be addressed separately.