### PR TITLE
Fix HLS bitrate calculation to comply with RFC 8216

### DIFF
--- a/Source/Python/utils/mp4-dash.py
+++ b/Source/Python/utils/mp4-dash.py
@@ -842,6 +842,7 @@ def OutputHlsIframeIndex(options, track, all_tracks, media_subdir, iframes_playl
     iframe_bitrate = 0
     iframe_max_bitrate = 0
     iframe_average_segment_bitrate = 0
+    target_duration = math.ceil(max(track.segment_durations))
 
     if not options.split:
         # get the I-frame index for a single file
@@ -856,13 +857,15 @@ def OutputHlsIframeIndex(options, track, all_tracks, media_subdir, iframes_playl
                 iframe_offset     = int(index_entry['offset'])
                 iframe_size       = int(index_entry['size'])
 
-                iframe_total_segment_size += iframe_size
+                iframe_range_size = iframe_size + (iframe_offset-fragment_start)
+                iframe_total_segment_size += iframe_range_size
                 iframe_total_segment_duration += iframe_segment_duration
-                iframe_bitrate = 8.0*(iframe_size/iframe_segment_duration)
-                if iframe_bitrate > iframe_max_bitrate:
+                iframe_bitrate = 8.0 * (iframe_range_size/iframe_segment_duration)
+                # The peak segment bit rate of a Media Playlist is the largest bit rate
+                # of any contiguous set of segments whose total duration is between 0.5 and 1.5 times the target duration. 
+                if iframe_bitrate > iframe_max_bitrate and (iframe_segment_duration >= 0.5 * target_duration and iframe_segment_duration <= 1.5 * target_duration):
                     iframe_max_bitrate = iframe_bitrate
 
-                iframe_range_size = iframe_size + (iframe_offset-fragment_start)
                 index_playlist_file.write('#EXT-X-BYTERANGE:{}@{}\n'.format(iframe_range_size, fragment_start))
                 index_playlist_file.write(media_file_name+'\n')
     else:
@@ -885,11 +888,14 @@ def OutputHlsIframeIndex(options, track, all_tracks, media_subdir, iframes_playl
             index_playlist_file.write('#EXT-X-BYTERANGE:{}@0\n'.format(iframe_range_size))
             index_playlist_file.write(fragment_basename+'\n')
 
-            iframe_total_segment_size += iframe_size
+            iframe_total_segment_size += iframe_range_size
             iframe_total_segment_duration += iframe_segment_duration
 
-            iframe_bitrate = 8.0*(iframe_size/iframe_segment_duration)
-            if iframe_bitrate > iframe_max_bitrate:
+            iframe_bitrate = 8.0*(iframe_range_size/iframe_segment_duration)
+            # The peak segment bit rate of a Media Playlist is the largest bit rate
+            # of any contiguous set of segments whose total duration is between 0.5
+            # and 1.5 times the target duration. 
+            if iframe_bitrate > iframe_max_bitrate and (iframe_segment_duration >= 0.5 * target_duration and iframe_segment_duration <= 1.5 * target_duration):
                 iframe_max_bitrate = iframe_bitrate
 
     index_playlist_file.write('#EXT-X-ENDLIST\n')

--- a/Source/Python/utils/mp4-dash.py
+++ b/Source/Python/utils/mp4-dash.py
@@ -839,9 +839,8 @@ def OutputHlsIframeIndex(options, track, all_tracks, media_subdir, iframes_playl
 
     iframe_total_segment_size = 0
     iframe_total_segment_duration = 0
-    iframe_bitrate = 0
-    iframe_max_bitrate = 0
     iframe_average_segment_bitrate = 0
+    iframe_segments = []  # (size, duration) pairs collected for peak bitrate calculation
     target_duration = math.ceil(max(track.segment_durations))
 
     if not options.split:
@@ -860,11 +859,7 @@ def OutputHlsIframeIndex(options, track, all_tracks, media_subdir, iframes_playl
                 iframe_range_size = iframe_size + (iframe_offset-fragment_start)
                 iframe_total_segment_size += iframe_range_size
                 iframe_total_segment_duration += iframe_segment_duration
-                iframe_bitrate = 8.0 * (iframe_range_size/iframe_segment_duration)
-                # The peak segment bit rate of a Media Playlist is the largest bit rate
-                # of any contiguous set of segments whose total duration is between 0.5 and 1.5 times the target duration. 
-                if iframe_bitrate > iframe_max_bitrate and (iframe_segment_duration >= 0.5 * target_duration and iframe_segment_duration <= 1.5 * target_duration):
-                    iframe_max_bitrate = iframe_bitrate
+                iframe_segments.append((iframe_range_size, iframe_segment_duration))
 
                 index_playlist_file.write('#EXT-X-BYTERANGE:{}@{}\n'.format(iframe_range_size, fragment_start))
                 index_playlist_file.write(media_file_name+'\n')
@@ -891,14 +886,26 @@ def OutputHlsIframeIndex(options, track, all_tracks, media_subdir, iframes_playl
             iframe_total_segment_size += iframe_range_size
             iframe_total_segment_duration += iframe_segment_duration
 
-            iframe_bitrate = 8.0*(iframe_range_size/iframe_segment_duration)
-            # The peak segment bit rate of a Media Playlist is the largest bit rate
-            # of any contiguous set of segments whose total duration is between 0.5
-            # and 1.5 times the target duration. 
-            if iframe_bitrate > iframe_max_bitrate and (iframe_segment_duration >= 0.5 * target_duration and iframe_segment_duration <= 1.5 * target_duration):
-                iframe_max_bitrate = iframe_bitrate
+            iframe_segments.append((iframe_range_size, iframe_segment_duration))
 
     index_playlist_file.write('#EXT-X-ENDLIST\n')
+    
+    # Per HLS spec: peak bitrate = largest bitrate of any contiguous set of segments
+    # whose total duration is between 0.5 and 1.5 times the target duration.
+    # The bitrate of a set = sum(sizes) / sum(durations).
+    iframe_max_bitrate = 0
+    for i in range(len(iframe_segments)):
+        total_size = 0
+        total_duration = 0
+        for j in range(i, len(iframe_segments)):
+            total_size += iframe_segments[j][0]
+            total_duration += iframe_segments[j][1]
+            if total_duration > 1.5 * target_duration:
+                break
+            if total_duration >= 0.5 * target_duration:
+                bitrate = 8.0 * total_size / total_duration
+                if bitrate > iframe_max_bitrate:
+                    iframe_max_bitrate = bitrate
 
     if iframe_total_segment_duration:
         iframe_average_segment_bitrate = 8.0*(iframe_total_segment_size/iframe_total_segment_duration)

--- a/Source/Python/utils/mp4utils.py
+++ b/Source/Python/utils/mp4utils.py
@@ -524,13 +524,23 @@ class Mp4Track:
 
         # compute the max segment bitrates
         if len(self.segment_bitrates) > 1:
-            # The peak segment bit rate of a Media Playlist is the largest bit rate
-            # of any contiguous set of segments whose total duration is between 0.5 and 1.5 times the target duration. 
+            # Per HLS spec: peak bitrate = largest bitrate of any contiguous set of segments
+            # whose total duration is between 0.5 and 1.5 times the target duration.
+            # The bitrate of a set = sum(sizes) / sum(durations).
             target_duration = math.ceil(max(self.segment_durations))
             self.max_segment_bitrate = 0
             for i in range(len(self.segment_durations)):
-                if self.segment_durations[i] >= target_duration * 0.5 and self.segment_durations[i] <= target_duration * 1.5:
-                    self.max_segment_bitrate = max(self.segment_bitrates[i], self.max_segment_bitrate)
+                total_size = 0
+                total_duration = 0
+                for j in range(i, len(self.segment_durations)):
+                    total_size += self.segment_sizes[j]
+                    total_duration += self.segment_durations[j]
+                    if total_duration > 1.5 * target_duration:
+                        break
+                    if total_duration >= 0.5 * target_duration:
+                        bitrate = 8.0 * total_size / total_duration
+                        if bitrate > self.max_segment_bitrate:
+                            self.max_segment_bitrate = bitrate
         else:
             self.max_segment_bitrate = self.average_segment_bitrate
 

--- a/Source/Python/utils/mp4utils.py
+++ b/Source/Python/utils/mp4utils.py
@@ -16,6 +16,7 @@ import hashlib
 import fractions
 import xml.sax.saxutils as saxutils
 import base64
+import math
 
 LanguageCodeMap = {
     'aar': 'aa', 'abk': 'ab', 'afr': 'af', 'aka': 'ak', 'alb': 'sq', 'amh': 'am', 'ara': 'ar', 'arg': 'an',
@@ -523,7 +524,13 @@ class Mp4Track:
 
         # compute the max segment bitrates
         if len(self.segment_bitrates) > 1:
-            self.max_segment_bitrate = max(self.segment_bitrates[:-1])
+            # The peak segment bit rate of a Media Playlist is the largest bit rate
+            # of any contiguous set of segments whose total duration is between 0.5 and 1.5 times the target duration. 
+            target_duration = math.ceil(max(self.segment_durations))
+            self.max_segment_bitrate = 0
+            for i in range(len(self.segment_durations)):
+                if self.segment_durations[i] >= target_duration * 0.5 and self.segment_durations[i] <= target_duration * 1.5:
+                    self.max_segment_bitrate = max(self.segment_bitrates[i], self.max_segment_bitrate)
         else:
             self.max_segment_bitrate = self.average_segment_bitrate
 


### PR DESCRIPTION
### Background

Apple Media Stream Validator reports the following error when validating HLS content generated by Bento4:

```
Error: Measured peak bitrate compared to multivariant playlist declared value exceeds error tolerance
--> Detail:  Measured: 1027.50 kb/s, Multivariant playlist: 724.21 kb/s, Error: 41.88%
--> Source:  output_hls/master.m3u8
--> Compare: video-av01-1.m3u8
```

The generated BANDWIDTH value are significantly lower than the values measured by the validator, causing HLS compliance failures.

### Reproduction

Media files:

https://github.com/user-attachments/assets/a4c59e3a-af7e-4382-b617-396b83f2989b


https://github.com/user-attachments/assets/50c74744-6d4a-4e39-a946-4ef143ea6299


Test script:

```bash
#!/bin/bash

BENTO4_DIR="$PWD"
MP4_FRAG="$BENTO4_DIR/cmakebuild/mp4fragment"
MP4_DASH="$BENTO4_DIR/Source/Python/utils/mp4-dash.py"

INPUT_MP4_1="$BENTO4_DIR/ChromaPulse__HDR10__1280x720_30fps__BT2100_PQ__AV1.mp4"
INPUT_MP4_2="$BENTO4_DIR/ChromaPulse__HDR10__1920x1080_30fps__BT2100_PQ__AV1.mp4"

# Fragment
$MP4_FRAG $INPUT_MP4_1 frag_720p.mp4
$MP4_FRAG $INPUT_MP4_2 frag_1080p.mp4

# Package
$MP4_DASH --hls -f --profile "on-demand" --no-split \
    -o output_hls/ \
    frag_720p.mp4 frag_1080p.mp4

# Validate
mediastreamvalidator \
    -O output_hls/validator.json \
    output_hls/master.m3u8
```

### Issue explanation

The bitrate calculation logic does not fully follow the requirements defined by **[RFC 8216](https://datatracker.ietf.org/doc/html/rfc8216)**.

**1. Peak bitrate calculation does not follow RFC 8216**

RFC 8216 specifies:

> The peak segment bit rate of a Media Playlist is the largest bit rate
> of any contiguous set of segments whose total duration is between 0.5
> and 1.5 times the target duration.  The bit rate of a set is
> calculated by dividing the sum of the segment sizes by the sum of the
> segment durations.

The existing implementation derives peak bitrate from individual segments and does not evaluate all valid contiguous segment windows within the required duration range.

As a result, the calculated peak bitrate may underestimate the actual peak bandwidth required by clients.

**2. I-frame average bitrate is calculated from sample sizes instead of byte-range sizes**

```python
 iframe_total_segment_size += iframe_size
```

RFC 8216 defines average segment bitrate as:

> The average segment bit rate of a Media Playlist is the sum of the
> sizes (in bits) of every Media Segment in the Media Playlist, divided
> by the Media Playlist duration.  Note that this includes container
> overhead, but not HTTP or other overhead imposed by the delivery
> system.

For I-frame playlists, clients retrieve the byte ranges referenced by the playlist rather than the raw I-frame samples themselves. Therefore, the transferred data size corresponds to the referenced byte ranges, including container overhead.

The existing implementation uses I-frame sample sizes when computing average bitrate, which systematically underestimates the actual amount of data delivered to clients and produces lower-than-expected AVERAGE-BANDWIDTH values.

**3. Last I-frame excluded from peak bitrate calculation**

```python
            self.max_segment_bitrate = max(self.segment_bitrates[:-1])
```

The current implementation excludes the final I-frame entry when evaluating peak bitrate.

Since every I-frame playlist entry represents a valid media resource that may be requested by a client, excluding the final entry artificially reduces the search space used for bitrate estimation and may underestimate the resulting peak bitrate.

Including all I-frame entries ensures that bandwidth calculations are based on the complete playlist contents and remain consistent with the RFC definition.

### Changes

1. Reworked peak bitrate calculation to follow RFC 8216 requirements.

2. Evaluate contiguous segment windows whose total duration falls within the required range relative to the target duration.

3. Use I-frame byte-range sizes when calculating I-frame average bitrate.

4. Include the final I-frame entry in peak bitrate calculations.

After applying this change, the bitrate-related validation error is no longer reported by Apple Media Stream Validator.

Validator output after this fix:

```
--------------------------------------------------------------------------------
MUST fix issues
--------------------------------------------------------------------------------

Error: Detected segment video transfer function does not match playlist declared video range
--> Detail:  Playlist attribute SDR, Video transfer function SMPTE_ST_2084_PQ
--> Source:  output_hls/master.m3u8
--> Compare: video-av01-1.m3u8

--> Detail:  Playlist attribute SDR, Video transfer function SMPTE_ST_2084_PQ
--> Source:  output_hls/master.m3u8
--> Compare: video-av01-1_iframes.m3u8

--> Detail:  Playlist attribute SDR, Video transfer function SMPTE_ST_2084_PQ
--> Source:  output_hls/master.m3u8
--> Compare: video-av01-2_iframes.m3u8

--> Detail:  Playlist attribute SDR, Video transfer function SMPTE_ST_2084_PQ
--> Source:  output_hls/master.m3u8
--> Compare: video-av01-2.m3u8

--------------------------------------------------------------------------------
```

The bitrate validation issue has been resolved. The remaining VIDEO-RANGE validation errors are unrelated and should be addressed separately.