### PR TITLE
Fix heap buffer overflow in AP4_BitReader::ReadCache (issue #1066)

### DIFF
--- a/Source/C++/Core/Ap4Utils.cpp
+++ b/Source/C++/Core/Ap4Utils.cpp
@@ -443,6 +443,11 @@ AP4_BitReader::GetBitsRead()
 AP4_BitReader::BitsWord
 AP4_BitReader::ReadCache() const
 {
+    // stop reading past the end of the buffer when more bits are requested
+    // than the input contains; the missing bytes read as zero
+    if (m_Position+AP4_WORD_BYTES > m_Buffer.GetBufferSize()) {
+        return 0;
+    }
     const AP4_UI08* out_ptr = m_Buffer.GetData()+m_Position;
     return (((AP4_BitReader::BitsWord) out_ptr[0]) << 24) |
            (((AP4_BitReader::BitsWord) out_ptr[1]) << 16) |


### PR DESCRIPTION
This fixes the heap-buffer-overflow reported in issue #1066 when parsing a malformed HEVC slice segment header. ReadCache() reads a full word at m_Position without checking the buffer bounds, so once a parser like ReadGolomb consumes more bits than the input contains, m_Position advances past the end of the buffer and the read goes out of bounds; the guard returns zero for the missing bytes, which matches the existing zero-padding behavior.