### PR TITLE
[Ap4CommonEncryption] Treat aux info of exactly iv_size bytes as "IV only, zero subsamples"

### DIFF
--- a/Source/C++/Core/Ap4CommonEncryption.cpp
+++ b/Source/C++/Core/Ap4CommonEncryption.cpp
@@ -2992,17 +2992,30 @@ AP4_CencSampleInfoTable::Create(AP4_UI08                  flags,
                 } else {
                     table->SetIv(saiz_index, constant_iv);
                 }
-                if (info_size < per_sample_iv_size+2) {
+                // Aux info layouts we must accept:
+                //   1) [IV][subsample_count:2][subsample_map:subsample_count*6]
+                //      (subsample encryption, e.g. video with cleartext slice
+                //      headers mixed with encrypted payload)
+                //   2) [IV]                                  (no subsample info)
+                //      (whole-sample encryption, common for audio where every
+                //      byte of the sample is encrypted and there is nothing
+                //      to describe — valid per ISO/IEC 23001-7)
+                AP4_UI16 subsample_count = 0;
+                if (info_size >= per_sample_iv_size+2) {
+                    subsample_count = AP4_BytesToUInt16BE(info_data+per_sample_iv_size);
+                    if (info_size < per_sample_iv_size+2+subsample_count*6) {
+                        // not enough data
+                        result = AP4_ERROR_INVALID_FORMAT;
+                        goto end;
+                    }
+                    table->AddSubSampleData(subsample_count, info_data+per_sample_iv_size+2);
+                } else if (info_size == per_sample_iv_size) {
+                    // IV-only aux info: whole sample is encrypted, no subsamples.
+                    table->AddSubSampleData(0, NULL);
+                } else {
                     result = AP4_ERROR_INVALID_FORMAT;
                     goto end;
                 }
-                AP4_UI16 subsample_count = AP4_BytesToUInt16BE(info_data+per_sample_iv_size);
-                if (info_size < per_sample_iv_size+2+subsample_count*6) {
-                    // not enough data
-                    result = AP4_ERROR_INVALID_FORMAT;
-                    goto end;
-                }
-                table->AddSubSampleData(subsample_count, info_data+per_sample_iv_size+2);
                 saiz_index++;
             }
         }


### PR DESCRIPTION
proposed fix from original issue https://github.com/xbmc/inputstream.adaptive/issues/2015 by @drewvs
i only upstreamed the code change, i cant test it by myself
please evaluate PR

`AP4_CencSampleInfoTable::Create` in `Source/C++/Core/Ap4CommonEncryption.cpp` rejects sample auxiliary information that is exactly `iv_size` bytes long (IV only, no subsample map) with `AP4_ERROR_INVALID_FORMAT`. This is a valid CENC layout for protected samples that do not use subsample encryption — e.g. audio tracks, where the whole sample is encrypted in one piece and there is no need for a subsample count / subsample map.

Content that uses this layout (YouTube TV / YouTube Music VOD, and likely other services) silently fails to decrypt

Root cause
```cpp
if (per_sample_iv_size) {
    if (per_sample_iv_size > info_size) {
        result = AP4_ERROR_INVALID_FORMAT;
        goto end;
    }
    table->SetIv(saiz_index, info_data);
} else {
    table->SetIv(saiz_index, constant_iv);
}
if (info_size < per_sample_iv_size+2) {     // <-- bug
    result = AP4_ERROR_INVALID_FORMAT;
    goto end;
}
AP4_UI16 subsample_count = AP4_BytesToUInt16BE(info_data+per_sample_iv_size);
if (info_size < per_sample_iv_size+2+subsample_count*6) {
    result = AP4_ERROR_INVALID_FORMAT;
    goto end;
}
table->AddSubSampleData(subsample_count, info_data+per_sample_iv_size+2);
```

The second `if` unconditionally requires two more bytes after the IV for a `subsample_count` field. Per ISO/IEC 23001-7 (Common Encryption), subsample mapping is not mandatory — it is only required when the `UseSubsampleEncryption` flag is set in the sample encryption box (senc) or when the sample has cleartext portions that must be distinguished from encrypted ones. Audio samples where every byte is encrypted need only the IV.