### PR TITLE
support dv_feature_flags (for dolby vision 2) and dv_md_compression

### DIFF
--- a/Source/C++/Apps/Mp4Mux/Mp4Mux.cpp
+++ b/Source/C++/Apps/Mp4Mux/Mp4Mux.cpp
@@ -94,12 +94,18 @@ PrintUsageAndExit()
             "    optional params:\n"
             "      dv_profile: integer number for Dolby vision profile ID (valid value: 9)\n"
             "      dv_bc: integer number for Dolby vision BL signal cross-compatibility ID (must be 2 if dv_profile is set to 9)\n"
+            "      dv_md_compression: integer number for Dolby vision metadata compression (valid value: 0, 1, 2, 3. default = 0)\n"
+            "      dv_feature_flags: a hex number to indicate 10-bit Dolby Vision features\n"
+            "            (example: if set 0x200, content has been authored for a Dolby Vision 2 experience. default = 0)\n"
             "      frame_rate: floating point number in frames per second (default=24.0)\n"
             "      format: avc1 (default) or avc3  for AVC tracks and Dolby Vision back-compatible tracks\n"
             "  h265: H265/HEVC NAL units\n"
             "    optional params:\n"
             "      dv_profile: integer number for Dolby vision profile ID (valid value: 5,8)\n"
             "      dv_bc: integer number for Dolby vision BL signal cross-compatibility ID (mandatory if dv_profile is set to 8)\n"
+            "      dv_md_compression: integer number for Dolby vision metadata compression (valid value: 0, 1, 2, 3. default = 0)\n"
+            "      dv_feature_flags: a hex number to indicate 10-bit Dolby Vision features\n"
+            "            (example: if set 0x200, content has been authored for a Dolby Vision 2 experience. default = 0)\n"
             "      frame_rate: floating point number in frames per second (default=24.0)\n"
             "      format: hev1 or hvc1 (default) for HEVC tracks and Dolby Vision backward-compatible tracks\n"
             "              dvhe or dvh1 (default) for Dolby vision tracks\n"
@@ -1230,6 +1236,8 @@ AddH264DoviTrack(AP4_Movie&            movie,
     AP4_UI32 dv_profile = 0;
     AP4_UI32 dv_bl_signal_comp_id = 0;
     AP4_UI32 dv_level = 0;
+    AP4_UI32 dv_md_compression = 0;
+    AP4_UI32 dv_feature_flags = 0;
 
     AP4_UI32 format = 0;
 
@@ -1269,6 +1277,15 @@ AddH264DoviTrack(AP4_Movie&            movie,
             dv_profile = atoi(parameters[i].m_Value.GetChars());
         } else if (parameters[i].m_Name == "dv_bc") {
             dv_bl_signal_comp_id = atoi(parameters[i].m_Value.GetChars());
+        } else if (parameters[i].m_Name == "dv_md_compression") {
+            dv_md_compression = atoi(parameters[i].m_Value.GetChars());
+        } else if (parameters[i].m_Name == "dv_feature_flags") {
+            dv_feature_flags = (AP4_UI32)strtol(parameters[i].m_Value.GetChars(), NULL, 0);
+            if (dv_feature_flags > 0x3FF) {
+                fprintf(stderr, "ERROR: invalid dv_feature_flags %s\n", parameters[i].m_Value.GetChars());
+                input->Release();
+                return;
+            }
         }
     }
 
@@ -1448,7 +1465,9 @@ AddH264DoviTrack(AP4_Movie&            movie,
                                          dv_rpu_flag,
                                          dv_el_flag,
                                          dv_bl_flag,
-                                         dv_bl_signal_comp_id);
+                                         dv_bl_signal_comp_id,
+                                         dv_md_compression,
+                                         dv_feature_flags);
     sample_table->AddSampleDescription(sample_description);
 
     AP4_UI32 movie_timescale      = 1000;
@@ -1795,6 +1814,8 @@ AddH265DoviTrack(AP4_Movie&           movie,
     AP4_UI32 dv_profile = 0;
     AP4_UI32 dv_bl_signal_comp_id = 0;
     AP4_UI32 dv_level = 0;
+    AP4_UI32 dv_md_compression = 0;
+    AP4_UI32 dv_feature_flags = 0;
 
     AP4_UI32 format = 0;
     
@@ -1834,6 +1855,15 @@ AddH265DoviTrack(AP4_Movie&           movie,
             dv_profile = atoi(parameters[i].m_Value.GetChars());
         } else if (parameters[i].m_Name == "dv_bc") {
             dv_bl_signal_comp_id = atoi(parameters[i].m_Value.GetChars());
+        } else if (parameters[i].m_Name == "dv_md_compression") {
+            dv_md_compression = atoi(parameters[i].m_Value.GetChars());
+        } else if (parameters[i].m_Name == "dv_feature_flags") {
+            dv_feature_flags = (AP4_UI32)strtol(parameters[i].m_Value.GetChars(), NULL, 0);
+            if (dv_feature_flags > 0x3FF) {
+                fprintf(stderr, "ERROR: invalid dv_feature_flags %s\n", parameters[i].m_Value.GetChars());
+                input->Release();
+                return;
+            }
         }
     }
     
@@ -2062,7 +2092,9 @@ AddH265DoviTrack(AP4_Movie&           movie,
                                           dv_rpu_flag,
                                           dv_el_flag,
                                           dv_bl_flag,
-                                          dv_bl_signal_comp_id);
+                                          dv_bl_signal_comp_id,
+                                          dv_md_compression,
+                                          dv_feature_flags);
     
     sample_table->AddSampleDescription(sample_description);
 

--- a/Source/C++/Apps/Mp4Mux/Mp4Mux.cpp
+++ b/Source/C++/Apps/Mp4Mux/Mp4Mux.cpp
@@ -1279,6 +1279,11 @@ AddH264DoviTrack(AP4_Movie&            movie,
             dv_bl_signal_comp_id = atoi(parameters[i].m_Value.GetChars());
         } else if (parameters[i].m_Name == "dv_md_compression") {
             dv_md_compression = atoi(parameters[i].m_Value.GetChars());
+            if (dv_md_compression > 3 || dv_md_compression < 0) {
+                fprintf(stderr, "ERROR: invalid dv_md_compression %s\n", parameters[i].m_Value.GetChars());
+                input->Release();
+                return;
+            }
         } else if (parameters[i].m_Name == "dv_feature_flags") {
             dv_feature_flags = (AP4_UI32)strtol(parameters[i].m_Value.GetChars(), NULL, 0);
             if (dv_feature_flags > 0x3FF) {
@@ -1857,6 +1862,11 @@ AddH265DoviTrack(AP4_Movie&           movie,
             dv_bl_signal_comp_id = atoi(parameters[i].m_Value.GetChars());
         } else if (parameters[i].m_Name == "dv_md_compression") {
             dv_md_compression = atoi(parameters[i].m_Value.GetChars());
+            if (dv_md_compression > 3 || dv_md_compression < 0) {
+                fprintf(stderr, "ERROR: invalid dv_md_compression %s\n", parameters[i].m_Value.GetChars());
+                input->Release();
+                return;
+            }
         } else if (parameters[i].m_Name == "dv_feature_flags") {
             dv_feature_flags = (AP4_UI32)strtol(parameters[i].m_Value.GetChars(), NULL, 0);
             if (dv_feature_flags > 0x3FF) {

--- a/Source/C++/Apps/Mp4Mux/Mp4Mux.cpp
+++ b/Source/C++/Apps/Mp4Mux/Mp4Mux.cpp
@@ -95,8 +95,8 @@ PrintUsageAndExit()
             "      dv_profile: integer number for Dolby vision profile ID (valid value: 9)\n"
             "      dv_bc: integer number for Dolby vision BL signal cross-compatibility ID (must be 2 if dv_profile is set to 9)\n"
             "      dv_md_compression: integer number for Dolby vision metadata compression (valid value: 0, 1, 2, 3. default = 0)\n"
-            "      dv_feature_flags: a hex number to indicate 10-bit Dolby Vision features\n"
-            "            (example: if set 0x200, content has been authored for a Dolby Vision 2 experience. default = 0)\n"
+            "      dv_feature_flags: a hex number to indicate 10-bit Dolby Vision features (valid value: 0x0, 0x200, default = 0x0)\n"
+            "                        if set 0x200, content has been authored for a Dolby Vision 2 experience\n"
             "      frame_rate: floating point number in frames per second (default=24.0)\n"
             "      format: avc1 (default) or avc3  for AVC tracks and Dolby Vision back-compatible tracks\n"
             "  h265: H265/HEVC NAL units\n"
@@ -104,8 +104,8 @@ PrintUsageAndExit()
             "      dv_profile: integer number for Dolby vision profile ID (valid value: 5,8)\n"
             "      dv_bc: integer number for Dolby vision BL signal cross-compatibility ID (mandatory if dv_profile is set to 8)\n"
             "      dv_md_compression: integer number for Dolby vision metadata compression (valid value: 0, 1, 2, 3. default = 0)\n"
-            "      dv_feature_flags: a hex number to indicate 10-bit Dolby Vision features\n"
-            "            (example: if set 0x200, content has been authored for a Dolby Vision 2 experience. default = 0)\n"
+            "      dv_feature_flags: a hex number to indicate 10-bit Dolby Vision features (valid value: 0x0, 0x200, default = 0x0)\n"
+            "                        if set 0x200, content has been authored for a Dolby Vision 2 experience\n"
             "      frame_rate: floating point number in frames per second (default=24.0)\n"
             "      format: hev1 or hvc1 (default) for HEVC tracks and Dolby Vision backward-compatible tracks\n"
             "              dvhe or dvh1 (default) for Dolby vision tracks\n"
@@ -1279,14 +1279,14 @@ AddH264DoviTrack(AP4_Movie&            movie,
             dv_bl_signal_comp_id = atoi(parameters[i].m_Value.GetChars());
         } else if (parameters[i].m_Name == "dv_md_compression") {
             dv_md_compression = atoi(parameters[i].m_Value.GetChars());
-            if (dv_md_compression > 3 || dv_md_compression < 0) {
+            if (dv_md_compression > 3) {
                 fprintf(stderr, "ERROR: invalid dv_md_compression %s\n", parameters[i].m_Value.GetChars());
                 input->Release();
                 return;
             }
         } else if (parameters[i].m_Name == "dv_feature_flags") {
             dv_feature_flags = (AP4_UI32)strtol(parameters[i].m_Value.GetChars(), NULL, 0);
-            if (dv_feature_flags > 0x3FF) {
+            if (dv_feature_flags != 0 && dv_feature_flags != 0x200) {
                 fprintf(stderr, "ERROR: invalid dv_feature_flags %s\n", parameters[i].m_Value.GetChars());
                 input->Release();
                 return;
@@ -1862,14 +1862,14 @@ AddH265DoviTrack(AP4_Movie&           movie,
             dv_bl_signal_comp_id = atoi(parameters[i].m_Value.GetChars());
         } else if (parameters[i].m_Name == "dv_md_compression") {
             dv_md_compression = atoi(parameters[i].m_Value.GetChars());
-            if (dv_md_compression > 3 || dv_md_compression < 0) {
+            if (dv_md_compression > 3) {
                 fprintf(stderr, "ERROR: invalid dv_md_compression %s\n", parameters[i].m_Value.GetChars());
                 input->Release();
                 return;
             }
         } else if (parameters[i].m_Name == "dv_feature_flags") {
             dv_feature_flags = (AP4_UI32)strtol(parameters[i].m_Value.GetChars(), NULL, 0);
-            if (dv_feature_flags > 0x3FF) {
+            if (dv_feature_flags != 0 && dv_feature_flags != 0x200) {
                 fprintf(stderr, "ERROR: invalid dv_feature_flags %s\n", parameters[i].m_Value.GetChars());
                 input->Release();
                 return;

--- a/Source/C++/Core/Ap4DvccAtom.cpp
+++ b/Source/C++/Core/Ap4DvccAtom.cpp
@@ -81,7 +81,9 @@ AP4_DvccAtom::Create(AP4_Size size, AP4_ByteStream& stream)
                             (payload[3]&4) != 0,
                             (payload[3]&2) != 0,
                             (payload[3]&1) != 0,
-                            payload[4]>>4);
+                            payload[4]>>4,
+                            (payload[4]&12)>>2,
+                            (payload[4]&3)<<8 | payload[5]);
 }
 
 /*----------------------------------------------------------------------
@@ -96,7 +98,9 @@ AP4_DvccAtom::AP4_DvccAtom() :
     m_RpuPresentFlag(false),
     m_ElPresentFlag(false),
     m_BlPresentFlag(false),
-    m_DvBlSignalCompatibilityID(0)
+    m_DvBlSignalCompatibilityID(0),
+    m_DvMdCompression(0),
+    m_DvFeatureFlags(0)
 {
 }
 
@@ -110,7 +114,9 @@ AP4_DvccAtom::AP4_DvccAtom(AP4_UI08 dv_version_major,
                            bool     rpu_present_flag,
                            bool     el_present_flag,
                            bool     bl_present_flag,
-                           AP4_UI08 dv_bl_signal_compatibility_id) :
+                           AP4_UI08 dv_bl_signal_compatibility_id,
+                           AP4_UI08 dv_md_compression,
+                           AP4_UI16 dv_feature_flags) :
     AP4_Atom((dv_profile>7) ? AP4_ATOM_TYPE_DVVC : AP4_ATOM_TYPE_DVCC, AP4_ATOM_HEADER_SIZE+24),
     m_DvVersionMajor(dv_version_major),
     m_DvVersionMinor(dv_version_minor),
@@ -119,7 +125,9 @@ AP4_DvccAtom::AP4_DvccAtom(AP4_UI08 dv_version_major,
     m_RpuPresentFlag(rpu_present_flag),
     m_ElPresentFlag(el_present_flag),
     m_BlPresentFlag(bl_present_flag),
-    m_DvBlSignalCompatibilityID(dv_bl_signal_compatibility_id)
+    m_DvBlSignalCompatibilityID(dv_bl_signal_compatibility_id),
+    m_DvMdCompression(dv_md_compression),
+    m_DvFeatureFlags(dv_feature_flags)
 {
 }
 
@@ -195,7 +203,8 @@ AP4_DvccAtom::WriteFields(AP4_ByteStream& stream)
     payload[1] = m_DvVersionMinor;
     payload[2] = (m_DvProfile<<1) | ((m_DvLevel&0x20)>>5);
     payload[3] = (m_DvLevel<<3) | (m_RpuPresentFlag?4:0) | (m_ElPresentFlag?2:0) | (m_BlPresentFlag?1:0);
-    payload[4] = m_DvBlSignalCompatibilityID<<4;
+    payload[4] = (m_DvBlSignalCompatibilityID<<4) | (m_DvMdCompression<<2) | (m_DvFeatureFlags>>8);
+    payload[5] = m_DvFeatureFlags&0xFF;
     
     return stream.Write(payload, 24);
 }
@@ -220,5 +229,7 @@ AP4_DvccAtom::InspectFields(AP4_AtomInspector& inspector)
     inspector.AddField("el_present_flag",  m_ElPresentFlag);
     inspector.AddField("bl_present_flag",  m_BlPresentFlag);
     inspector.AddField("dv_bl_signal_compatibility_id", m_DvBlSignalCompatibilityID);
+    inspector.AddField("dv_md_compression", m_DvMdCompression);
+    inspector.AddField("dv_feature_flags", m_DvFeatureFlags);
     return AP4_SUCCESS;
 }

--- a/Source/C++/Core/Ap4DvccAtom.h
+++ b/Source/C++/Core/Ap4DvccAtom.h
@@ -75,7 +75,9 @@ public:
                  bool     rpu_present_flag,
                  bool     el_present_flag,
                  bool     bl_present_flag,
-                 AP4_UI08 dv_bl_signal_compatibility_id);
+                 AP4_UI08 dv_bl_signal_compatibility_id,
+                 AP4_UI08 dv_md_compression,
+                 AP4_UI16 dv_feature_flags);
     
     // methods
     virtual AP4_Result InspectFields(AP4_AtomInspector& inspector);
@@ -90,6 +92,8 @@ public:
     bool     GetElPresentFlag()  { return m_ElPresentFlag  != 0; }
     bool     GetBlPresentFlag()  { return m_BlPresentFlag  != 0; }
     AP4_UI08 GetDvBlSignalCompatibilityID() { return m_DvBlSignalCompatibilityID; }
+    AP4_UI08 GetDvMdCompression() { return m_DvMdCompression; }
+    AP4_UI08 GetDvFeatureFlags() { return m_DvFeatureFlags; }
 
     // helpers
     AP4_Result GetCodecString(const char* parent_codec_string,
@@ -106,6 +110,8 @@ private:
     AP4_UI08 m_ElPresentFlag;
     AP4_UI08 m_BlPresentFlag;
     AP4_UI08 m_DvBlSignalCompatibilityID;
+    AP4_UI08 m_DvMdCompression;
+    AP4_UI16 m_DvFeatureFlags;
 };
 
 #endif // _AP4_DVCC_ATOM_H_

--- a/Source/C++/Core/Ap4DvccAtom.h
+++ b/Source/C++/Core/Ap4DvccAtom.h
@@ -93,7 +93,7 @@ public:
     bool     GetBlPresentFlag()  { return m_BlPresentFlag  != 0; }
     AP4_UI08 GetDvBlSignalCompatibilityID() { return m_DvBlSignalCompatibilityID; }
     AP4_UI08 GetDvMdCompression() { return m_DvMdCompression; }
-    AP4_UI08 GetDvFeatureFlags() { return m_DvFeatureFlags; }
+    AP4_UI16 GetDvFeatureFlags() { return m_DvFeatureFlags; }
 
     // helpers
     AP4_Result GetCodecString(const char* parent_codec_string,

--- a/Source/C++/Core/Ap4SampleDescription.cpp
+++ b/Source/C++/Core/Ap4SampleDescription.cpp
@@ -459,7 +459,9 @@ AP4_AvcDoviSampleDescription::AP4_AvcDoviSampleDescription(AP4_UI32             
                                                            bool                             rpu_present_flag,
                                                            bool                             el_present_flag,
                                                            bool                             bl_present_flag,
-                                                           AP4_UI08                         dv_bl_signal_compatibility_id) :
+                                                           AP4_UI08                         dv_bl_signal_compatibility_id,
+                                                           AP4_UI08                         dv_md_compression,
+                                                           AP4_UI16                         dv_feature_flags) :
     AP4_AvcSampleDescription(format,
                              width,
                              height,
@@ -482,7 +484,9 @@ AP4_AvcDoviSampleDescription::AP4_AvcDoviSampleDescription(AP4_UI32             
                                   rpu_present_flag,
                                   el_present_flag,
                                   bl_present_flag,
-                                  dv_bl_signal_compatibility_id);
+                                  dv_bl_signal_compatibility_id,
+                                  dv_md_compression,
+                                  dv_feature_flags);
     m_Details.AddChild(m_DvccAtom);
 }
 
@@ -694,7 +698,9 @@ AP4_HevcDoviSampleDescription::AP4_HevcDoviSampleDescription(AP4_UI32           
                                                              bool                             rpu_present_flag,
                                                              bool                             el_present_flag,
                                                              bool                             bl_present_flag,
-                                                             AP4_UI08                         dv_bl_signal_compatibility_id) :
+                                                             AP4_UI08                         dv_bl_signal_compatibility_id,
+                                                             AP4_UI08                         dv_md_compression,
+                                                             AP4_UI16                         dv_feature_flags) :
     AP4_HevcSampleDescription(format,
                               width,
                               height,
@@ -730,7 +736,9 @@ AP4_HevcDoviSampleDescription::AP4_HevcDoviSampleDescription(AP4_UI32           
                                   rpu_present_flag,
                                   el_present_flag,
                                   bl_present_flag,
-                                  dv_bl_signal_compatibility_id);
+                                  dv_bl_signal_compatibility_id,
+                                  dv_md_compression,
+                                  dv_feature_flags);
     m_Details.AddChild(m_DvccAtom);
 }
 

--- a/Source/C++/Core/Ap4SampleDescription.h
+++ b/Source/C++/Core/Ap4SampleDescription.h
@@ -378,7 +378,9 @@ public:
                                      bool                             rpu_present_flag,
                                      bool                             el_present_flag,
                                      bool                             bl_present_flag,
-                                     AP4_UI08                         dv_bl_signal_compatibility_id);
+                                     AP4_UI08                         dv_bl_signal_compatibility_id,
+                                     AP4_UI08                         dv_md_compression,
+                                     AP4_UI16                         dv_feature_flags);
 private:
     AP4_DvccAtom* m_DvccAtom;
 };
@@ -509,7 +511,9 @@ public:
                                   bool                             rpu_present_flag,
                                   bool                             el_present_flag,
                                   bool                             bl_present_flag,
-                                  AP4_UI08                         dv_bl_signal_compatibility_id);
+                                  AP4_UI08                         dv_bl_signal_compatibility_id,
+                                  AP4_UI08                         dv_md_compression,
+                                  AP4_UI16                         dv_feature_flags);
 private:
     AP4_DvccAtom* m_DvccAtom;
 };


### PR DESCRIPTION
- support the signal of `dv_feature_flags` and `dv_md_compression`
- `dv_feature_flags` can be used to indicate Dolby Vision 2 experience

Reference: _Dolby Vision Streams Within the ISO Base Media File Format specification Version 2.7.1 Section 2.2_